### PR TITLE
Typos and naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ mk.stat.median(b) // meadian
 #### Copying arrays
 ```kotlin
 val f = a.clone() // create a copy of the array and its data
-val h = b.deepCope() // create a copy of the array and copy the meaningful data
+val h = b.deepCopy() // create a copy of the array and copy the meaningful data
 ```
 
 #### Operations of Iterable

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ val h = b.deepCopy() // create a copy of the array and copy the meaningful data
 ```kotlin
 c.filter { it < 3 } // select all elements less than 3
 b.map { (it * it).toInt() } // return squares
-c.groupNdarrayBy { it % 2 } // group elemetns by condition
+c.groupNDArrayBy { it % 2 } // group elements by condition
 c.sorted() // sort elements
 ```
 
@@ -184,7 +184,7 @@ for (el in b) {
 }
 
 // for n-dimensional
-val q = b.asDNArray()
+val q = b.asNDArray()
 for (index in q.multiIndices) {
     print("${q[index]}, ") // 1.5, 2.1, 3.0, 4.0, 5.0, 6.0, 
 }

--- a/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/DotBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/DotBenchmark.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlinx.multik.jni.NativeLinAlg
 import org.jetbrains.kotlinx.multik.jvm.JvmLinAlg
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
 import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
@@ -29,7 +29,7 @@ open class DotBenchmark {
     var size: Int = 0
     private lateinit var arg1: D2Array<Double>
     private lateinit var arg2: D2Array<Double>
-    private lateinit var result: Ndarray<Double, D2>
+    private lateinit var result: NDArray<Double, D2>
     private lateinit var ran: Random
 
     @Setup

--- a/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/ExpBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/ExpBenchmark.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlinx.multik.jni.NativeMath
 import org.jetbrains.kotlinx.multik.jvm.JvmMath
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
 import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.data.get
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
@@ -29,7 +29,7 @@ open class ExpBenchmark {
     @Param("10", "100", "1000")
     var size: Int = 0
     private lateinit var arg: D2Array<Double>
-    private lateinit var result: Ndarray<Double, D2>
+    private lateinit var result: NDArray<Double, D2>
     private lateinit var ran: Random
 
     @Setup

--- a/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/LogBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/LogBenchmark.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlinx.multik.jni.NativeMath
 import org.jetbrains.kotlinx.multik.jvm.JvmMath
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
 import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.data.get
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
@@ -28,7 +28,7 @@ open class LogBenchmark {
     @Param("10", "100", "1000")
     var size: Int = 0
     private lateinit var arg: D2Array<Double>
-    private lateinit var result: Ndarray<Double, D2>
+    private lateinit var result: NDArray<Double, D2>
     private lateinit var ran: Random
 
     @Setup

--- a/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/SinBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/org/jetbrains/kotlinx/multik/SinBenchmark.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlinx.multik.jni.NativeMath
 import org.jetbrains.kotlinx.multik.jvm.JvmMath
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
 import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.data.get
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
@@ -28,7 +28,7 @@ open class SinBenchmark {
     @Param("10", "100", "1000")
     var size: Int = 0
     private lateinit var arg: D2Array<Double>
-    private lateinit var result: Ndarray<Double, D2>
+    private lateinit var result: NDArray<Double, D2>
     private lateinit var ran: Random
 
     @Setup

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/CreateNDArray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/CreateNDArray.kt
@@ -13,16 +13,16 @@ import kotlin.math.ceil
  * Returns a new zero array with the specified shape.
  *
  * @param dims shape of the array.
- * @return [Ndarray] of [D] dimension
- * @sample samples.Ndarray.empty
+ * @return [NDArray] of [D] dimension
+ * @sample samples.NDArrayTest.empty
  */
-public inline fun <reified T : Number, reified D : Dimension> Multik.empty(vararg dims: Int): Ndarray<T, D> {
+public inline fun <reified T : Number, reified D : Dimension> Multik.empty(vararg dims: Int): NDArray<T, D> {
     val dim = dimensionClassOf<D>(dims.size)
     requireDimension(dim, dims.size)
     val dtype = DataType.of(T::class)
     val size = dims.reduce { acc, el -> acc * el }
     val data = initMemoryView<T>(size, dtype)
-    return Ndarray<T, D>(data, shape = dims, dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = dims, dtype = dtype, dim = dim)
 }
 
 /**
@@ -32,16 +32,16 @@ public inline fun <reified T : Number, reified D : Dimension> Multik.empty(varar
  *
  * @param dims shape of the array.
  * @param dtype array type.
- * @return [Ndarray] of [D] dimension.
- * @sample samples.Ndarray.emptyWithDtype
+ * @return [NDArray] of [D] dimension.
+ * @sample samples.NDArrayTest.emptyWithDtype
  */
-public fun <T : Number, D : Dimension> Multik.empty(dims: IntArray, dtype: DataType): Ndarray<T, D> {
+public fun <T : Number, D : Dimension> Multik.empty(dims: IntArray, dtype: DataType): NDArray<T, D> {
     // TODO check data type
     val dim = dimensionOf<D>(dims.size)
     requireDimension(dim, dims.size) // TODO (mk.empty<Float, D2>(intArrayOf(3), DataType.FloatDataType))
     val size = dims.fold(1, Int::times)
     val data = initMemoryView<T>(size, dtype)
-    return Ndarray<T, D>(data, shape = dims, dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = dims, dtype = dtype, dim = dim)
 }
 
 /**
@@ -49,7 +49,7 @@ public fun <T : Number, D : Dimension> Multik.empty(dims: IntArray, dtype: DataT
  *
  * @param n number of rows and columns.
  * @return [D2Array].
- * @sample samples.Ndarray.identity
+ * @sample samples.NDArrayTest.identity
  */
 public inline fun <reified T : Number> Multik.identity(n: Int): D2Array<T> {
     val dtype = DataType.of(T::class)
@@ -64,7 +64,7 @@ public inline fun <reified T : Number> Multik.identity(n: Int): D2Array<T> {
  * @param n number of rows and columns.
  * @param dtype array type.
  * @return [D2Array]
- * @sample samples.Ndarray.identityWithDtype
+ * @sample samples.NDArrayTest.identityWithDtype
  */
 public fun <T : Number> Multik.identity(n: Int, dtype: DataType): D2Array<T> {
     val shape = intArrayOf(n, n)
@@ -94,7 +94,7 @@ public fun <T : Number> Multik.identity(n: Int, dtype: DataType): D2Array<T> {
  * ```
  * @param arg list of elements.
  * @return [D1Array].
- * @sample samples.Ndarray.ndarray1D
+ * @sample samples.NDArrayTest.ndarray1D
  */
 @JvmName("ndarray1D")
 public inline fun <reified T : Number> Multik.ndarray(arg: List<T>): D1Array<T> {
@@ -109,7 +109,7 @@ public inline fun <reified T : Number> Multik.ndarray(arg: List<T>): D1Array<T> 
  *
  * @param arg list of rows.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarray2D
+ * @sample samples.NDArrayTest.ndarray2D
  */
 @JvmName("ndarray2D")
 public inline fun <reified T : Number> Multik.ndarray(arg: List<List<T>>): D2Array<T> {
@@ -131,7 +131,7 @@ public inline fun <reified T : Number> Multik.ndarray(arg: List<List<T>>): D2Arr
  *
  * @param arg elements.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarray3D
+ * @sample samples.NDArrayTest.ndarray3D
  */
 @JvmName("ndarray3D")
 public inline fun <reified T : Number> Multik.ndarray(arg: List<List<List<T>>>): D3Array<T> {
@@ -157,7 +157,7 @@ public inline fun <reified T : Number> Multik.ndarray(arg: List<List<List<T>>>):
  *
  * @param arg elements.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarray4D
+ * @sample samples.NDArrayTest.ndarray4D
  */
 @JvmName("ndarray4D")
 public inline fun <reified T : Number> Multik.ndarray(arg: List<List<List<List<T>>>>): D4Array<T> {
@@ -188,12 +188,12 @@ public inline fun <reified T : Number> Multik.ndarray(arg: List<List<List<List<T
  *
  * @param elements collection of elements.
  * @param shape array shape.
- * @return [Ndarray] of [D] dimension.
- * @sample samples.Ndarray.ndarrayCollections
+ * @return [NDArray] of [D] dimension.
+ * @sample samples.NDArrayTest.ndarrayCollections
  */
 public inline fun <T : Number, reified D : Dimension> Multik.ndarray(
     elements: Collection<T>, shape: IntArray
-): Ndarray<T, D> {
+): NDArray<T, D> {
     requireShapeEmpty(shape)
     val dim = dimensionClassOf<D>(shape.size)
     requireDimension(dim, shape.size)
@@ -208,10 +208,10 @@ public inline fun <T : Number, reified D : Dimension> Multik.ndarray(
  * @param elements collection of elements.
  * @param shape array shape.
  * @param dim array dimension.
- * @return [Ndarray] of [D] dimension.
- * @sample samples.Ndarray.ndarrayCollectionsWithDim
+ * @return [NDArray] of [D] dimension.
+ * @sample samples.NDArrayTest.ndarrayCollectionsWithDim
  */
-public fun <T : Number, D : Dimension> Multik.ndarray(elements: Collection<T>, shape: IntArray, dim: D): Ndarray<T, D> {
+public fun <T : Number, D : Dimension> Multik.ndarray(elements: Collection<T>, shape: IntArray, dim: D): NDArray<T, D> {
     requireShapeEmpty(shape)
     requireDimension(dim, shape.size)
     requireElementsWithShape(elements.size, shape.fold(1, Int::times))
@@ -222,7 +222,7 @@ public fun <T : Number, D : Dimension> Multik.ndarray(elements: Collection<T>, s
         for (el in elements)
             this[count++] = el
     }
-    return Ndarray<T, D>(data, shape = shape, dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape, dtype = dtype, dim = dim)
 }
 
 //_________________________________________________D1___________________________________________________________________
@@ -232,7 +232,7 @@ public fun <T : Number, D : Dimension> Multik.ndarray(elements: Collection<T>, s
  *
  * @param elements collection of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayCollections1D
+ * @sample samples.NDArrayTest.ndarrayCollections1D
  */
 public fun <T : Number> Multik.ndarray(elements: Collection<T>): D1Array<T> {
     return ndarray(elements, intArrayOf(elements.size), D1)
@@ -243,7 +243,7 @@ public fun <T : Number> Multik.ndarray(elements: Collection<T>): D1Array<T> {
  *
  * @param args [ByteArray] of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayByteArray1D
+ * @sample samples.NDArrayTest.ndarrayByteArray1D
  */
 public fun Multik.ndarray(args: ByteArray): D1Array<Byte> {
     val data = MemoryViewByteArray(args)
@@ -255,7 +255,7 @@ public fun Multik.ndarray(args: ByteArray): D1Array<Byte> {
  *
  * @param args [ShortArray] of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayShortArray1D
+ * @sample samples.NDArrayTest.ndarrayShortArray1D
  */
 public fun Multik.ndarray(args: ShortArray): D1Array<Short> {
     val data = MemoryViewShortArray(args)
@@ -267,7 +267,7 @@ public fun Multik.ndarray(args: ShortArray): D1Array<Short> {
  *
  * @param args [IntArray] of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayIntArray1D
+ * @sample samples.NDArrayTest.ndarrayIntArray1D
  */
 public fun Multik.ndarray(args: IntArray): D1Array<Int> {
     val data = MemoryViewIntArray(args)
@@ -279,7 +279,7 @@ public fun Multik.ndarray(args: IntArray): D1Array<Int> {
  *
  * @param args [LongArray] of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayLongArray1D
+ * @sample samples.NDArrayTest.ndarrayLongArray1D
  */
 public fun Multik.ndarray(args: LongArray): D1Array<Long> {
     val data = MemoryViewLongArray(args)
@@ -291,7 +291,7 @@ public fun Multik.ndarray(args: LongArray): D1Array<Long> {
  *
  * @param args [FloatArray] of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayFloatArray1D
+ * @sample samples.NDArrayTest.ndarrayFloatArray1D
  */
 public fun Multik.ndarray(args: FloatArray): D1Array<Float> {
     val data = MemoryViewFloatArray(args)
@@ -303,7 +303,7 @@ public fun Multik.ndarray(args: FloatArray): D1Array<Float> {
  *
  * @param args [DoubleArray] of elements.
  * @return [D1Array]
- * @sample samples.Ndarray.ndarrayDoubleArray1D
+ * @sample samples.NDArrayTest.ndarrayDoubleArray1D
  */
 public fun Multik.ndarray(args: DoubleArray): D1Array<Double> {
     val data = MemoryViewDoubleArray(args)
@@ -319,7 +319,7 @@ public fun Multik.ndarray(args: DoubleArray): D1Array<Double> {
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayCollections2D
+ * @sample samples.NDArrayTest.ndarrayCollections2D
  */
 public fun <T : Number> Multik.ndarray(elements: Collection<T>, dim1: Int, dim2: Int): D2Array<T> {
     return ndarray(elements, intArrayOf(dim1, dim2), D2)
@@ -332,7 +332,7 @@ public fun <T : Number> Multik.ndarray(elements: Collection<T>, dim1: Int, dim2:
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayByteArray2D
+ * @sample samples.NDArrayTest.ndarrayByteArray2D
  */
 public fun Multik.ndarray(args: ByteArray, dim1: Int, dim2: Int): D2Array<Byte> {
     requireElementsWithShape(args.size, dim1 * dim2)
@@ -347,7 +347,7 @@ public fun Multik.ndarray(args: ByteArray, dim1: Int, dim2: Int): D2Array<Byte> 
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayShortArray2D
+ * @sample samples.NDArrayTest.ndarrayShortArray2D
  */
 public fun Multik.ndarray(args: ShortArray, dim1: Int, dim2: Int): D2Array<Short> {
     requireElementsWithShape(args.size, dim1 * dim2)
@@ -362,7 +362,7 @@ public fun Multik.ndarray(args: ShortArray, dim1: Int, dim2: Int): D2Array<Short
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayIntArray2D
+ * @sample samples.NDArrayTest.ndarrayIntArray2D
  */
 public fun Multik.ndarray(args: IntArray, dim1: Int, dim2: Int): D2Array<Int> {
     requireElementsWithShape(args.size, dim1 * dim2)
@@ -377,7 +377,7 @@ public fun Multik.ndarray(args: IntArray, dim1: Int, dim2: Int): D2Array<Int> {
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayLongArray2D
+ * @sample samples.NDArrayTest.ndarrayLongArray2D
  */
 public fun Multik.ndarray(args: LongArray, dim1: Int, dim2: Int): D2Array<Long> {
     requireElementsWithShape(args.size, dim1 * dim2)
@@ -392,7 +392,7 @@ public fun Multik.ndarray(args: LongArray, dim1: Int, dim2: Int): D2Array<Long> 
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayFloatArray2D
+ * @sample samples.NDArrayTest.ndarrayFloatArray2D
  */
 public fun Multik.ndarray(args: FloatArray, dim1: Int, dim2: Int): D2Array<Float> {
     requireElementsWithShape(args.size, dim1 * dim2)
@@ -407,7 +407,7 @@ public fun Multik.ndarray(args: FloatArray, dim1: Int, dim2: Int): D2Array<Float
  * @param dim1 value of 1-dimension.
  * @param dim2 value of 1-dimension.
  * @return [D2Array].
- * @sample samples.Ndarray.ndarrayDoubleArray2D
+ * @sample samples.NDArrayTest.ndarrayDoubleArray2D
  */
 public fun Multik.ndarray(args: DoubleArray, dim1: Int, dim2: Int): D2Array<Double> {
     requireElementsWithShape(args.size, dim1 * dim2)
@@ -425,7 +425,7 @@ public fun Multik.ndarray(args: DoubleArray, dim1: Int, dim2: Int): D2Array<Doub
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayCollections3D
+ * @sample samples.NDArrayTest.ndarrayCollections3D
  */
 public fun <T : Number> Multik.ndarray(elements: Collection<T>, dim1: Int, dim2: Int, dim3: Int): D3Array<T> {
     return ndarray(elements, intArrayOf(dim1, dim2, dim3), D3)
@@ -439,7 +439,7 @@ public fun <T : Number> Multik.ndarray(elements: Collection<T>, dim1: Int, dim2:
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayByteArray3D
+ * @sample samples.NDArrayTest.ndarrayByteArray3D
  */
 public fun Multik.ndarray(args: ByteArray, dim1: Int, dim2: Int, dim3: Int): D3Array<Byte> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3)
@@ -455,7 +455,7 @@ public fun Multik.ndarray(args: ByteArray, dim1: Int, dim2: Int, dim3: Int): D3A
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayShortArray3D
+ * @sample samples.NDArrayTest.ndarrayShortArray3D
  */
 public fun Multik.ndarray(args: ShortArray, dim1: Int, dim2: Int, dim3: Int): D3Array<Short> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3)
@@ -471,7 +471,7 @@ public fun Multik.ndarray(args: ShortArray, dim1: Int, dim2: Int, dim3: Int): D3
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayIntArray3D
+ * @sample samples.NDArrayTest.ndarrayIntArray3D
  */
 public fun Multik.ndarray(args: IntArray, dim1: Int, dim2: Int, dim3: Int): D3Array<Int> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3)
@@ -487,7 +487,7 @@ public fun Multik.ndarray(args: IntArray, dim1: Int, dim2: Int, dim3: Int): D3Ar
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayLongArray3D
+ * @sample samples.NDArrayTest.ndarrayLongArray3D
  */
 public fun Multik.ndarray(args: LongArray, dim1: Int, dim2: Int, dim3: Int): D3Array<Long> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3)
@@ -503,7 +503,7 @@ public fun Multik.ndarray(args: LongArray, dim1: Int, dim2: Int, dim3: Int): D3A
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayFloatArray3D
+ * @sample samples.NDArrayTest.ndarrayFloatArray3D
  */
 public fun Multik.ndarray(args: FloatArray, dim1: Int, dim2: Int, dim3: Int): D3Array<Float> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3)
@@ -519,7 +519,7 @@ public fun Multik.ndarray(args: FloatArray, dim1: Int, dim2: Int, dim3: Int): D3
  * @param dim2 value of 2-dimension.
  * @param dim3 value of 3-dimension.
  * @return [D3Array].
- * @sample samples.Ndarray.ndarrayDoubleArray3D
+ * @sample samples.NDArrayTest.ndarrayDoubleArray3D
  */
 public fun Multik.ndarray(args: DoubleArray, dim1: Int, dim2: Int, dim3: Int): D3Array<Double> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3)
@@ -538,7 +538,7 @@ public fun Multik.ndarray(args: DoubleArray, dim1: Int, dim2: Int, dim3: Int): D
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayCollections4D
+ * @sample samples.NDArrayTest.ndarrayCollections4D
  */
 public fun <T : Number> Multik.ndarray(
     elements: Collection<T>, dim1: Int, dim2: Int, dim3: Int, dim4: Int
@@ -555,7 +555,7 @@ public fun <T : Number> Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayByteArray4D
+ * @sample samples.NDArrayTest.ndarrayByteArray4D
  */
 public fun Multik.ndarray(args: ByteArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<Byte> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3 * dim4)
@@ -572,7 +572,7 @@ public fun Multik.ndarray(args: ByteArray, dim1: Int, dim2: Int, dim3: Int, dim4
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayShortArray4D
+ * @sample samples.NDArrayTest.ndarrayShortArray4D
  */
 public fun Multik.ndarray(args: ShortArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<Short> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3 * dim4)
@@ -589,7 +589,7 @@ public fun Multik.ndarray(args: ShortArray, dim1: Int, dim2: Int, dim3: Int, dim
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayIntArray4D
+ * @sample samples.NDArrayTest.ndarrayIntArray4D
  */
 public fun Multik.ndarray(args: IntArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<Int> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3 * dim4)
@@ -606,7 +606,7 @@ public fun Multik.ndarray(args: IntArray, dim1: Int, dim2: Int, dim3: Int, dim4:
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayLongArray4D
+ * @sample samples.NDArrayTest.ndarrayLongArray4D
  */
 public fun Multik.ndarray(args: LongArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<Long> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3 * dim4)
@@ -623,7 +623,7 @@ public fun Multik.ndarray(args: LongArray, dim1: Int, dim2: Int, dim3: Int, dim4
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayFloatArray4D
+ * @sample samples.NDArrayTest.ndarrayFloatArray4D
  */
 public fun Multik.ndarray(args: FloatArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<Float> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3 * dim4)
@@ -640,7 +640,7 @@ public fun Multik.ndarray(args: FloatArray, dim1: Int, dim2: Int, dim3: Int, dim
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @return [D4Array].
- * @sample samples.Ndarray.ndarrayDoubleArray4D
+ * @sample samples.NDArrayTest.ndarrayDoubleArray4D
  */
 public fun Multik.ndarray(args: DoubleArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<Double> {
     requireElementsWithShape(args.size, dim1 * dim2 * dim3 * dim4)
@@ -659,12 +659,12 @@ public fun Multik.ndarray(args: DoubleArray, dim1: Int, dim2: Int, dim3: Int, di
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayCollectionsDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayCollectionsDN
  */
 public fun <T : Number> Multik.ndarray(
     elements: Collection<T>, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<T, DN> {
+): NDArray<T, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     return ndarray(elements, shape, DN(shape.size))
 }
@@ -678,16 +678,16 @@ public fun <T : Number> Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayByteArrayDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayByteArrayDN
  */
 public fun Multik.ndarray(
     args: ByteArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<Byte, DN> {
+): NDArray<Byte, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     requireElementsWithShape(args.size, shape.fold(1, Int::times))
     val data = MemoryViewByteArray(args)
-    return Ndarray<Byte, DN>(data, shape = shape, dtype = DataType.ByteDataType, dim = dimensionOf(shape.size))
+    return NDArray<Byte, DN>(data, shape = shape, dtype = DataType.ByteDataType, dim = dimensionOf(shape.size))
 }
 
 /**
@@ -699,16 +699,16 @@ public fun Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayShortArrayDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayShortArrayDN
  */
 public fun Multik.ndarray(
     args: ShortArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<Short, DN> {
+): NDArray<Short, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     requireElementsWithShape(args.size, shape.fold(1, Int::times))
     val data = MemoryViewShortArray(args)
-    return Ndarray<Short, DN>(data, shape = shape, dtype = DataType.ShortDataType, dim = dimensionOf(shape.size))
+    return NDArray<Short, DN>(data, shape = shape, dtype = DataType.ShortDataType, dim = dimensionOf(shape.size))
 }
 
 /**
@@ -720,16 +720,16 @@ public fun Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayIntArrayDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayIntArrayDN
  */
 public fun Multik.ndarray(
     args: IntArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<Int, DN> {
+): NDArray<Int, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     requireElementsWithShape(args.size, shape.fold(1, Int::times))
     val data = MemoryViewIntArray(args)
-    return Ndarray<Int, DN>(data, shape = shape, dtype = DataType.IntDataType, dim = dimensionOf(shape.size))
+    return NDArray<Int, DN>(data, shape = shape, dtype = DataType.IntDataType, dim = dimensionOf(shape.size))
 }
 
 /**
@@ -741,16 +741,16 @@ public fun Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayLongArrayDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayLongArrayDN
  */
 public fun Multik.ndarray(
     args: LongArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<Long, DN> {
+): NDArray<Long, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     requireElementsWithShape(args.size, shape.fold(1, Int::times))
     val data = MemoryViewLongArray(args)
-    return Ndarray<Long, DN>(data, shape = shape, dtype = DataType.LongDataType, dim = dimensionOf(shape.size))
+    return NDArray<Long, DN>(data, shape = shape, dtype = DataType.LongDataType, dim = dimensionOf(shape.size))
 }
 
 /**
@@ -762,16 +762,16 @@ public fun Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayFloatArrayDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayFloatArrayDN
  */
 public fun Multik.ndarray(
     args: FloatArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<Float, DN> {
+): NDArray<Float, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     requireElementsWithShape(args.size, shape.fold(1, Int::times))
     val data = MemoryViewFloatArray(args)
-    return Ndarray<Float, DN>(data, shape = shape, dtype = DataType.FloatDataType, dim = dimensionOf(shape.size))
+    return NDArray<Float, DN>(data, shape = shape, dtype = DataType.FloatDataType, dim = dimensionOf(shape.size))
 }
 
 /**
@@ -783,16 +783,16 @@ public fun Multik.ndarray(
  * @param dim3 value of 3-dimension.
  * @param dim4 value of 4-dimension.
  * @param dims values of other dimensions.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.ndarrayDoubleArrayDN
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.ndarrayDoubleArrayDN
  */
 public fun Multik.ndarray(
     args: DoubleArray, dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int
-): Ndarray<Double, DN> {
+): NDArray<Double, DN> {
     val shape = intArrayOf(dim1, dim2, dim3, dim4) + dims
     requireElementsWithShape(args.size, shape.fold(1, Int::times))
     val data = MemoryViewDoubleArray(args)
-    return Ndarray<Double, DN>(data, shape = shape, dtype = DataType.DoubleDataType, dim = dimensionOf(shape.size))
+    return NDArray<Double, DN>(data, shape = shape, dtype = DataType.DoubleDataType, dim = dimensionOf(shape.size))
 }
 
 //______________________________________________________________________________________________________________________
@@ -803,7 +803,7 @@ public fun Multik.ndarray(
  * @param sizeD1 value of 1-dimension.
  * @param init initialization function
  * @return [D1Array].
- * @sample samples.Ndarray.d1array
+ * @sample samples.NDArrayTest.d1array
  */
 public inline fun <reified T : Number> Multik.d1array(sizeD1: Int, noinline init: (Int) -> T): D1Array<T> {
     val dtype = DataType.of(T::class)
@@ -819,7 +819,7 @@ public inline fun <reified T : Number> Multik.d1array(sizeD1: Int, noinline init
  * @param sizeD2 value of 2-dimension.
  * @param init initialization function.
  * @return [D2Array].
- * @sample samples.Ndarray.d2array
+ * @sample samples.NDArrayTest.d2array
  */
 public inline fun <reified T : Number> Multik.d2array(sizeD1: Int, sizeD2: Int, noinline init: (Int) -> T): D2Array<T> {
     val dtype = DataType.of(T::class)
@@ -836,7 +836,7 @@ public inline fun <reified T : Number> Multik.d2array(sizeD1: Int, sizeD2: Int, 
  * @param sizeD3 value of 3-dimension.
  * @param init initialization function.
  * @return [D3Array].
- * @sample samples.Ndarray.d3array
+ * @sample samples.NDArrayTest.d3array
  */
 public inline fun <reified T : Number> Multik.d3array(
     sizeD1: Int, sizeD2: Int, sizeD3: Int, noinline init: (Int) -> T
@@ -856,7 +856,7 @@ public inline fun <reified T : Number> Multik.d3array(
  * @param sizeD4 value of 4-dimension.
  * @param init initialization function.
  * @return [D4Array].
- * @sample samples.Ndarray.d4array
+ * @sample samples.NDArrayTest.d4array
  */
 public inline fun <reified T : Number> Multik.d4array(
     sizeD1: Int, sizeD2: Int, sizeD3: Int, sizeD4: Int, noinline init: (Int) -> T
@@ -877,17 +877,17 @@ public inline fun <reified T : Number> Multik.d4array(
  * @param sizeD4 value of 4-dimension.
  * @param dims values other dimensions.
  * @param init initialization function.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.dnarray
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.dnarray
  */
 public inline fun <reified T : Number> Multik.dnarray(
     sizeD1: Int, sizeD2: Int, sizeD3: Int, sizeD4: Int, vararg dims: Int, noinline init: (Int) -> T
-): Ndarray<T, DN> {
+): NDArray<T, DN> {
     val dtype = DataType.of(T::class)
     val shape = intArrayOf(sizeD1, sizeD2, sizeD3, sizeD4) + dims
     val size = shape.fold(1, Int::times)
     val data = initMemoryView<T>(size, dtype, init)
-    return Ndarray<T, DN>(data, shape = shape, dtype = dtype, dim = dimensionOf(shape.size))
+    return NDArray<T, DN>(data, shape = shape, dtype = dtype, dim = dimensionOf(shape.size))
 }
 
 /**
@@ -896,17 +896,17 @@ public inline fun <reified T : Number> Multik.dnarray(
  *
  * @param dims array shape.
  * @param init initialization function.
- * @return [Ndarray] of [DN] dimension.
- * @sample samples.Ndarray.dnarrayWithDims
+ * @return [NDArray] of [DN] dimension.
+ * @sample samples.NDArrayTest.dnarrayWithDims
  */
 public inline fun <reified T : Number, D : Dimension> Multik.dnarray(
     dims: IntArray,
     noinline init: (Int) -> T
-): Ndarray<T, D> {
+): NDArray<T, D> {
     val dtype = DataType.of(T::class)
     val size = dims.fold(1, Int::times)
     val data = initMemoryView<T>(size, dtype, init)
-    return Ndarray<T, D>(data, shape = dims, dtype = dtype, dim = dimensionOf(dims.size))
+    return NDArray<T, D>(data, shape = dims, dtype = dtype, dim = dimensionOf(dims.size))
 }
 
 /**
@@ -914,7 +914,7 @@ public inline fun <reified T : Number, D : Dimension> Multik.dnarray(
  *
  * @param items specified elements.
  * @return [D1Array].
- * @sample samples.Ndarray.ndarrayOf
+ * @sample samples.NDArrayTest.ndarrayOf
  */
 public fun <T : Number> Multik.ndarrayOf(vararg items: T): D1Array<T> {
     val dtype = DataType.of(items.first())
@@ -930,7 +930,7 @@ public fun <T : Number> Multik.ndarrayOf(vararg items: T): D1Array<T> {
  * @param stop end value of the interval. The interval doesn't include this value.
  * @param step spacing between value. The default step is 1.
  * @return [D1Array].
- * @sample samples.Ndarray.arange
+ * @sample samples.NDArrayTest.arange
  */
 public inline fun <reified T : Number> Multik.arange(start: Int, stop: Int, step: Int = 1): D1Array<T> {
     return arange(start, stop, step.toDouble())
@@ -943,7 +943,7 @@ public inline fun <reified T : Number> Multik.arange(start: Int, stop: Int, step
  * @param stop end value of the interval. The interval doesn't include this value.
  * @param step spacing between value. The step is [Double].
  * @return [D1Array].
- * @sample samples.Ndarray.arangeDoubleStep
+ * @sample samples.NDArrayTest.arangeDoubleStep
  */
 public inline fun <reified T : Number> Multik.arange(start: Int, stop: Int, step: Double): D1Array<T> {
     if (start < stop) require(step > 0) { "Step must be positive." }
@@ -969,7 +969,7 @@ public inline fun <reified T : Number> Multik.arange(start: Int, stop: Int, step
  * @param stop end of the interval. The interval doesn't include this value.
  * @param step spacing between value. The default step is 1.
  * @return [D1Array].
- * @sample samples.Ndarray.arangeWithoutStart
+ * @sample samples.NDArrayTest.arangeWithoutStart
  */
 public inline fun <reified T : Number> Multik.arange(stop: Int, step: Int = 1): D1Array<T> = arange(0, stop, step)
 
@@ -980,7 +980,7 @@ public inline fun <reified T : Number> Multik.arange(stop: Int, step: Int = 1): 
  * @param stop end value of the interval. The interval doesn't include this value.
  * @param step spacing between value. The step is [Double].
  * @return [D1Array].
- * @sample samples.Ndarray.arangeDoubleStepWithoutStart
+ * @sample samples.NDArrayTest.arangeDoubleStepWithoutStart
  */
 public inline fun <reified T : Number> Multik.arange(stop: Int, step: Double): D1Array<T> = arange(0, stop, step)
 
@@ -992,7 +992,7 @@ public inline fun <reified T : Number> Multik.arange(stop: Int, step: Double): D
  * @param stop end of the interval.
  * @param num number of values. Default is 50.
  * @return [D1Array].
- * @sample samples.Ndarray.linspace
+ * @sample samples.NDArrayTest.linspace
  */
 public inline fun <reified T : Number> Multik.linspace(start: Int, stop: Int, num: Int = 50): D1Array<T> {
     return linspace(start.toDouble(), stop.toDouble(), num)
@@ -1006,7 +1006,7 @@ public inline fun <reified T : Number> Multik.linspace(start: Int, stop: Int, nu
  * @param stop end of the interval.
  * @param num number of values.
  * @return [D1Array].
- * @sample samples.Ndarray.linspaceDouble
+ * @sample samples.NDArrayTest.linspaceDouble
  */
 public inline fun <reified T : Number> Multik.linspace(start: Double, stop: Double, num: Int = 50): D1Array<T> {
     require(num > 0) { "The number of elements cannot be less than zero or equal to zero." }
@@ -1025,9 +1025,9 @@ public inline fun <reified T : Number> Multik.linspace(start: Double, stop: Doub
 
 /**
  * Returns [D1Array] containing all elements.
- * @sample samples.Ndarray.toNdarray
+ * @sample samples.NDArrayTest.toNDArray
  */
-public fun <T : Number> Iterable<T>.toNdarray(): D1Array<T> {
+public fun <T : Number> Iterable<T>.toNDArray(): D1Array<T> {
     if (this is Collection<T>)
         return Multik.ndarray<T, D1>(this, intArrayOf(this.size), D1)
 

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/LinAlg.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/LinAlg.kt
@@ -15,7 +15,7 @@ public interface LinAlg {
     /**
      * Raise a square matrix to power [n].
      */
-    public fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): Ndarray<T, D2>
+    public fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): NDArray<T, D2>
 
     /**
      * Matrix ov vector norm. The default is Frobenius norm.
@@ -25,7 +25,7 @@ public interface LinAlg {
     /**
      * Dot products of two arrays. Matrix product.
      */
-    public fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): Ndarray<T, D>
+    public fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): NDArray<T, D>
 
     /**
      * Dot products of two one-dimensional arrays. Scalar product.

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/Math.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/Math.kt
@@ -12,84 +12,84 @@ import org.jetbrains.kotlinx.multik.ndarray.data.*
 public interface Math {
 
     /**
-     * Returns flat index of maximum element in a ndarray.
+     * Returns flat index of maximum element in an ndarray.
      */
     public fun <T : Number, D : Dimension> argMax(a: MultiArray<T, D>): Int
 
     /**
-     * Returns a ndarray of indices of maximum elements in a ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of maximum elements in an ndarray [a] over a given [axis].
      */
-    public fun <T : Number, D : Dimension, O: Dimension> argMax(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O>
+    public fun <T : Number, D : Dimension, O: Dimension> argMax(a: MultiArray<T, D>, axis: Int): NDArray<Int, O>
 
     /**
-     * Returns a ndarray of indices of maximum elements in a two-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of maximum elements in a two-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1>
+    public fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1>
 
     /**
-     * Returns a ndarray of indices of maximum elements in a three-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of maximum elements in a three-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2>
+    public fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2>
 
     /**
-     * Returns a ndarray of indices of maximum elements in a four-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of maximum elements in a four-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3>
+    public fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3>
 
     /**
-     * Returns a ndarray of indices of maximum elements in an n-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of maximum elements in an n-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4>
+    public fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4>
 
     /**
-     * Returns flat index of minimum element in a ndarray.
+     * Returns flat index of minimum element in an ndarray.
      */
     public fun <T : Number, D : Dimension> argMin(a: MultiArray<T, D>): Int
 
     /**
-     * Returns a ndarray of indices of minimum elements in a ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of minimum elements in an ndarray [a] over a given [axis].
      */
-    public fun <T : Number, D : Dimension, O: Dimension> argMin(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O>
+    public fun <T : Number, D : Dimension, O: Dimension> argMin(a: MultiArray<T, D>, axis: Int): NDArray<Int, O>
 
     /**
-     * Returns a ndarray of indices of minimum elements in a two-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of minimum elements in a two-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1>
+    public fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1>
 
     /**
-     * Returns a ndarray of indices of minimum elements in a three-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of minimum elements in a three-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2>
+    public fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2>
 
     /**
-     * Returns a ndarray of indices of minimum elements in a four-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of minimum elements in a four-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3>
+    public fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3>
 
     /**
-     * Returns a ndarray of indices of minimum elements in an n-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of indices of minimum elements in an n-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4>
+    public fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4>
 
     /**
-     * Returns a ndarray of Double from the given ndarray to each element of which an exp function has been applied.
+     * Returns an ndarray of Double from the given ndarray to each element of which an exp function has been applied.
      */
-    public fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): Ndarray<Double, D>
+    public fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): NDArray<Double, D>
 
     /**
-     * Returns a ndarray of Double from the given ndarray to each element of which a log function has been applied.
+     * Returns an ndarray of Double from the given ndarray to each element of which a log function has been applied.
      */
-    public fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): Ndarray<Double, D>
+    public fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): NDArray<Double, D>
 
     /**
-     * Returns a ndarray of Double from the given ndarray to each element of which a sin function has been applied.
+     * Returns an ndarray of Double from the given ndarray to each element of which a sin function has been applied.
      */
-    public fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): Ndarray<Double, D>
+    public fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): NDArray<Double, D>
 
     /**
-     * Returns a ndarray of Double from the given ndarray to each element of which a cos function has been applied.
+     * Returns an ndarray of Double from the given ndarray to each element of which a cos function has been applied.
      */
-    public fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): Ndarray<Double, D>
+    public fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): NDArray<Double, D>
 
     /**
      * Returns maximum element of the given ndarray.
@@ -97,29 +97,29 @@ public interface Math {
     public fun <T : Number, D : Dimension> max(a: MultiArray<T, D>): T
 
     /**
-     * Returns maximum of a ndarray [a] along a given [axis].
+     * Returns maximum of an ndarray [a] along a given [axis].
      */
-    public fun <T : Number, D : Dimension, O: Dimension> max(a: MultiArray<T, D>, axis: Int): Ndarray<T, O>
+    public fun <T : Number, D : Dimension, O: Dimension> max(a: MultiArray<T, D>, axis: Int): NDArray<T, O>
 
     /**
      * Returns maximum of a two-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1>
+    public fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1>
 
     /**
      * Returns maximum of a three-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2>
+    public fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2>
 
     /**
      * Returns maximum of a four-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3>
+    public fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3>
 
     /**
      * Returns maximum of an n-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4>
+    public fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4>
 
     /**
      * Returns minimum element of the given ndarray.
@@ -127,29 +127,29 @@ public interface Math {
     public fun <T : Number, D : Dimension> min(a: MultiArray<T, D>): T
 
     /**
-     * Returns minimum of a ndarray [a] along a given [axis].
+     * Returns minimum of an ndarray [a] along a given [axis].
      */
-    public fun <T : Number, D : Dimension, O: Dimension> min(a: MultiArray<T, D>, axis: Int): Ndarray<T, O>
+    public fun <T : Number, D : Dimension, O: Dimension> min(a: MultiArray<T, D>, axis: Int): NDArray<T, O>
 
     /**
      * Returns minimum of a two-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1>
+    public fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1>
 
     /**
      * Returns minimum of a three-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2>
+    public fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2>
 
     /**
      * Returns minimum of a four-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3>
+    public fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3>
 
     /**
      * Returns minimum of an n-dimensional ndarray [a] along a given [axis].
      */
-    public fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4>
+    public fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4>
 
     /**
      * Returns sum of all elements in the given ndarray.
@@ -157,29 +157,29 @@ public interface Math {
     public fun <T : Number, D : Dimension> sum(a: MultiArray<T, D>): T
 
     /**
-     * Returns a ndarray of sum all elements over a given [axis].
+     * Returns an ndarray of sum all elements over a given [axis].
      */
-    public fun <T: Number, D: Dimension, O: Dimension> sum(a: MultiArray<T, D>, axis: Int): Ndarray<T, O>
+    public fun <T: Number, D: Dimension, O: Dimension> sum(a: MultiArray<T, D>, axis: Int): NDArray<T, O>
 
     /**
-     * Returns a ndarray of sum all elements in a two-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of sum all elements in a two-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T: Number> sumD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1>
+    public fun <T: Number> sumD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1>
 
     /**
-     * Returns a ndarray of sum all elements in a three-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of sum all elements in a three-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T: Number> sumD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2>
+    public fun <T: Number> sumD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2>
 
     /**
-     * Returns a ndarray of sum all elements in a four-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of sum all elements in a four-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T: Number> sumD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3>
+    public fun <T: Number> sumD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3>
 
     /**
-     * Returns a ndarray of sum all elements in a n-dimensional ndarray [a] over a given [axis].
+     * Returns an ndarray of sum all elements in a n-dimensional ndarray [a] over a given [axis].
      */
-    public fun <T: Number> sumDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4>
+    public fun <T: Number> sumDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4>
 
     /**
      * Returns cumulative sum of all elements in the given ndarray.
@@ -189,5 +189,5 @@ public interface Math {
     /**
      * Returns cumulative sum of all elements in the given ndarray along the given [axis].
      */
-    public fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): Ndarray<T, D>
+    public fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): NDArray<T, D>
 }

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/Statistics.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/api/Statistics.kt
@@ -29,90 +29,90 @@ public interface Statistics {
     /**
      * Returns the arithmetic mean of the [a] elements along the given [axis].
      */
-    public fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): Ndarray<Double, O>
+    public fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): NDArray<Double, O>
 
     /**
      * Returns the arithmetic mean of the two-dimensional ndarray [a] elements along the given [axis].
      */
-    public fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Double, D1>
+    public fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): NDArray<Double, D1>
 
     /**
      * Returns the arithmetic mean of the three-dimensional ndarray [a] elements along the given [axis].
      */
-    public fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Double, D2>
+    public fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): NDArray<Double, D2>
 
     /**
      * Returns the arithmetic mean of the four-dimensional ndarray [a] elements along the given [axis].
      */
-    public fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Double, D3>
+    public fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3>
 
     /**
      * Returns the arithmetic mean of the n-dimensional ndarray [a] elements along the given [axis].
      */
-    public fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Double, D4>
+    public fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4>
 }
 
 /**
  * Returns the absolute value of the given ndarray [a].
  */
 @JvmName("absByte")
-public fun <D : Dimension> Statistics.abs(a: MultiArray<Byte, D>): Ndarray<Byte, D> {
+public fun <D : Dimension> Statistics.abs(a: MultiArray<Byte, D>): NDArray<Byte, D> {
     val ret = initMemoryView<Byte>(a.size, a.dtype)
     var index = 0
     for (element in a) {
         ret[index++] = absByte(element)
     }
-    return Ndarray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
+    return NDArray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
 }
 
 @JvmName("absShort")
-public fun <D : Dimension> Statistics.abs(a: MultiArray<Short, D>): Ndarray<Short, D> {
+public fun <D : Dimension> Statistics.abs(a: MultiArray<Short, D>): NDArray<Short, D> {
     val ret = initMemoryView<Short>(a.size, a.dtype)
     var index = 0
     for (element in a) {
         ret[index++] = absShort(element)
     }
-    return Ndarray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
+    return NDArray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
 }
 
 @JvmName("absInt")
-public fun <D : Dimension> Statistics.abs(a: MultiArray<Int, D>): Ndarray<Int, D> {
+public fun <D : Dimension> Statistics.abs(a: MultiArray<Int, D>): NDArray<Int, D> {
     val ret = initMemoryView<Int>(a.size, a.dtype)
     var index = 0
     for (element in a) {
         ret[index++] = kotlin.math.abs(element)
     }
-    return Ndarray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
+    return NDArray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
 }
 
 @JvmName("absLong")
-public fun <D : Dimension> Statistics.abs(a: MultiArray<Long, D>): Ndarray<Long, D> {
+public fun <D : Dimension> Statistics.abs(a: MultiArray<Long, D>): NDArray<Long, D> {
     val ret = initMemoryView<Long>(a.size, a.dtype)
     var index = 0
     for (element in a) {
         ret[index++] = kotlin.math.abs(element)
     }
-    return Ndarray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
+    return NDArray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
 }
 
 @JvmName("absFloat")
-public fun <D : Dimension> Statistics.abs(a: MultiArray<Float, D>): Ndarray<Float, D> {
+public fun <D : Dimension> Statistics.abs(a: MultiArray<Float, D>): NDArray<Float, D> {
     val ret = initMemoryView<Float>(a.size, a.dtype)
     var index = 0
     for (element in a) {
         ret[index++] = kotlin.math.abs(element)
     }
-    return Ndarray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
+    return NDArray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
 }
 
 @JvmName("absDouble")
-public fun <D : Dimension> Statistics.abs(a: MultiArray<Double, D>): Ndarray<Double, D> {
+public fun <D : Dimension> Statistics.abs(a: MultiArray<Double, D>): NDArray<Double, D> {
     val ret = initMemoryView<Double>(a.size, a.dtype)
     var index = 0
     for (element in a) {
         ret[index++] = kotlin.math.abs(element)
     }
-    return Ndarray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
+    return NDArray(ret, 0, a.shape.copyOf(), dtype = a.dtype, dim = a.dim)
 }
 
 private inline fun absByte(a: Byte): Byte = if (a < 0) (-a).toByte() else a

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/DataType.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/DataType.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
 /**
- * Describes the type of elements stored in a [Ndarray].
+ * Describes the type of elements stored in a [NDArray].
  *
  * @param nativeCode an integer value of the type. Required to define the type in JNI.
  * @param itemSize size of one ndarray element in bytes.

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MemoryView.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MemoryView.kt
@@ -5,7 +5,7 @@
 package org.jetbrains.kotlinx.multik.ndarray.data
 
 /**
- * View for storing data in a [Ndarray] and working them in a uniform style.
+ * View for storing data in a [NDArray] and working them in a uniform style.
  *
  * @property data one of the primitive arrays.
  */

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MultiArrays.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MultiArrays.kt
@@ -55,7 +55,7 @@ public interface MultiArray<T : Number, D : Dimension> {
     /**
      * Returns new [MultiArray] which is a deep copy of the original ndarray.
      */
-    public fun deepCope(): MultiArray<T, D>
+    public fun deepCopy(): MultiArray<T, D>
 
     public operator fun iterator(): Iterator<T>
 

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MultiArrays.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MultiArrays.kt
@@ -8,11 +8,11 @@ package org.jetbrains.kotlinx.multik.ndarray.data
  *  A generic ndarray. Methods in this interface support only read-only access to the ndarray.
  *
  *  @property data [MemoryView].
- *  @property offset Offset from the start of a ndarray's data.
- *  @property shape [IntArray] of a ndarray dimensions.
- *  @property strides [IntArray] indices to step in each dimension when iterating a ndarray.
- *  @property size number of elements in a ndarray.
- *  @property dtype [DataType] of a ndarray's data.
+ *  @property offset Offset from the start of an ndarray's data.
+ *  @property shape [IntArray] of an ndarray dimensions.
+ *  @property strides [IntArray] indices to step in each dimension when iterating an ndarray.
+ *  @property size number of elements in an ndarray.
+ *  @property dtype [DataType] of an ndarray's data.
  *  @property dim [Dimension].
  *  @property consistent indicates whether the array data is homogeneous.
  *  @property indices indices for a one-dimensional ndarray.
@@ -67,7 +67,7 @@ public interface MultiArray<T : Number, D : Dimension> {
 
     // Reshape
     /**
-     * Returns a ndarray with a new shape without changing data.
+     * Returns an ndarray with a new shape without changing data.
      */
     public fun reshape(dim1: Int): MultiArray<T, D1>
 
@@ -86,7 +86,7 @@ public interface MultiArray<T : Number, D : Dimension> {
 
     // TODO(maybe be done on one axis? like pytorch)
     /**
-     * Returns a ndarray with all axes removed equal to one.
+     * Returns an ndarray with all axes removed equal to one.
      */
     public fun squeeze(vararg axes: Int): MultiArray<T, DN>
 
@@ -105,7 +105,7 @@ public interface MultiArray<T : Number, D : Dimension> {
 
 //___________________________________________________ReadableView_______________________________________________________
 
-public class ReadableView<T : Number>(private val base: MultiArray<T, DN>) /*: BaseNdarray by base */ {
+public class ReadableView<T : Number>(private val base: MultiArray<T, DN>) /*: BaseNDArray by base */ {
     public operator fun get(vararg indices: Int): MultiArray<T, DN> {
         return indices.fold(this.base) { m, pos -> m.view(pos) }
     }
@@ -116,7 +116,7 @@ public fun <T : Number, D : Dimension, M : Dimension> MultiArray<T, D>.view(
 ): MultiArray<T, M> {
     //todo negative?
     if (index >= shape[axis]) throw ArrayIndexOutOfBoundsException("Index $index out of bounds shape dimension ${shape[axis]}")
-    return Ndarray<T, M>(
+    return NDArray<T, M>(
         data, offset + strides[axis] * index, shape.remove(axis),
         strides.remove(axis), this.dtype, dimensionOf(this.dim.d - 1)
     )
@@ -130,7 +130,7 @@ public fun <T : Number, D : Dimension, M : Dimension> MultiArray<T, D>.view(
     var newOffset = offset
     for (i in axes.indices)
         newOffset += strides[axes[i]] * index[i]
-    return Ndarray<T, M>(data, newOffset, newShape, newStrides, this.dtype, dimensionOf(this.dim.d - axes.size))
+    return NDArray<T, M>(data, newOffset, newShape, newStrides, this.dtype, dimensionOf(this.dim.d - axes.size))
 }
 
 @JvmName("viewD2")
@@ -220,7 +220,7 @@ public operator fun <T : Number> MultiArray<T, DN>.get(index: IntArray): T {
 
 //_______________________________________________GetWithSlice___________________________________________________________
 
-public fun <T: Number, D: Dimension, O: Dimension> MultiArray<T, D>.slice(slice: Slice, axis: Int = 0): Ndarray<T, O> {
+public fun <T: Number, D: Dimension, O: Dimension> MultiArray<T, D>.slice(slice: Slice, axis: Int = 0): NDArray<T, O> {
     //TODO (require)
 //    require(range.step > 0) { "slicing step must be positive, but was ${range.step}" }
 //    require(axis in 0 until this.dim.d) { "axis out of bounds: $axis" }
@@ -240,11 +240,11 @@ public fun <T: Number, D: Dimension, O: Dimension> MultiArray<T, D>.slice(slice:
     val sliceShape = shape.clone().apply {
         this[axis] = (actualTo - slice.start + slice.step - 1) / slice.step
     }
-    return Ndarray<T, O>(data, offset + slice.start * strides[axis], sliceShape, sliceStrides, this.dtype, dimensionOf(sliceShape.size))
+    return NDArray<T, O>(data, offset + slice.start * strides[axis], sliceShape, sliceStrides, this.dtype, dimensionOf(sliceShape.size))
 }
 
 
-public fun <T: Number, D: Dimension, O: Dimension> MultiArray<T, D>.slice(indexing: Map<Int, Indexing>): Ndarray<T, O> {
+public fun <T: Number, D: Dimension, O: Dimension> MultiArray<T, D>.slice(indexing: Map<Int, Indexing>): NDArray<T, O> {
     var newOffset = offset
     var newShape: IntArray = shape.clone()
     var newStrides: IntArray = strides.clone()
@@ -282,7 +282,7 @@ public fun <T: Number, D: Dimension, O: Dimension> MultiArray<T, D>.slice(indexi
 
     newShape = newShape.removeAll(removeAxes)
     newStrides = newStrides.removeAll(removeAxes)
-    return Ndarray<T, O>(this.data, newOffset, newShape, newStrides, this.dtype, dimensionOf(newShape.size))
+    return NDArray<T, O>(this.data, newOffset, newShape, newStrides, this.dtype, dimensionOf(newShape.size))
 }
 
 @JvmName("get12")
@@ -456,8 +456,8 @@ public fun <T: Number> MultiArray<T, DN>.slice(map: Map<Int, Indexing>): MultiAr
 
 //________________________________________________asDimension___________________________________________________________
 
-public fun <T : Number, D : Dimension> MultiArray<T, D>.asDNArray(): Ndarray<T, DN> {
-    if (this is Ndarray<T, D>)
-        return this.asDNArray()
-    else throw ClassCastException("Cannot cast MultiArray to Ndarray of dimension n.")
+public fun <T : Number, D : Dimension> MultiArray<T, D>.asNDArray(): NDArray<T, DN> {
+    if (this is NDArray<T, D>)
+        return this.asNDArray()
+    else throw ClassCastException("Cannot cast MultiArray to NDArray of dimension n.")
 }

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MutableMultiArrays.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MutableMultiArrays.kt
@@ -12,7 +12,7 @@ public interface MutableMultiArray<T : Number, D : Dimension> : MultiArray<T, D>
 
     override fun clone(): MutableMultiArray<T, D>
 
-    override fun deepCope(): MutableMultiArray<T, D>
+    override fun deepCopy(): MutableMultiArray<T, D>
 
     // Reshape
 

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/NDArray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/NDArray.kt
@@ -4,10 +4,10 @@
 
 package org.jetbrains.kotlinx.multik.ndarray.data
 
-public typealias D1Array<T> = Ndarray<T, D1>
-public typealias D2Array<T> = Ndarray<T, D2>
-public typealias D3Array<T> = Ndarray<T, D3>
-public typealias D4Array<T> = Ndarray<T, D4>
+public typealias D1Array<T> = NDArray<T, D1>
+public typealias D2Array<T> = NDArray<T, D2>
+public typealias D3Array<T> = NDArray<T, D3>
+public typealias D4Array<T> = NDArray<T, D4>
 
 /**
  * A class that implements multidimensional arrays. This implementation is based on primitive arrays.
@@ -19,7 +19,7 @@ public typealias D4Array<T> = Ndarray<T, D4>
  * @param T type of stored values.
  * @param D dimension.
  */
-public class Ndarray<T : Number, D : Dimension> constructor(
+public class NDArray<T : Number, D : Dimension> constructor(
     data: ImmutableMemoryView<T>,
     public override val offset: Int = 0,
     //TODO (check empty?!)
@@ -42,7 +42,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
     override val indices: IntRange
         get() {
             // todo?
-//            if (dim.d != 1) throw IllegalStateException("Ndarray of dimension ${dim.d}, use multiIndex.")
+//            if (dim.d != 1) throw IllegalStateException("NDArray of dimension ${dim.d}, use multiIndex.")
             return 0..size - 1
         }
 
@@ -55,27 +55,27 @@ public class Ndarray<T : Number, D : Dimension> constructor(
     public override fun isNotEmpty(): Boolean = !isEmpty()
 
     public override operator fun iterator(): Iterator<T> =
-        if (consistent) this.data.iterator() else NdarrayIterator(data, offset, strides, shape)
+        if (consistent) this.data.iterator() else NDArrayIterator(data, offset, strides, shape)
 
-    public inline fun <reified E : Number> asType(): Ndarray<E, D> {
+    public inline fun <reified E : Number> asType(): NDArray<E, D> {
         val dataType = DataType.of(E::class)
         return this.asType(dataType)
     }
 
-    public fun <E : Number> asType(dataType: DataType): Ndarray<E, D> {
+    public fun <E : Number> asType(dataType: DataType): NDArray<E, D> {
         val newData = initMemoryView<E>(this.data.size, dataType) { this.data[it] as E }
-        return Ndarray<E, D>(newData, this.offset, this.shape, this.strides, dataType, this.dim)
+        return NDArray<E, D>(newData, this.offset, this.shape, this.strides, dataType, this.dim)
     }
 
-    override fun clone(): Ndarray<T, D> =
-        Ndarray(this.data.copyOf(), this.offset, this.shape.copyOf(), this.strides.copyOf(), this.dtype, this.dim)
+    override fun clone(): NDArray<T, D> =
+        NDArray(this.data.copyOf(), this.offset, this.shape.copyOf(), this.strides.copyOf(), this.dtype, this.dim)
 
-    override fun deepCopy(): Ndarray<T, D> {
+    override fun deepCopy(): NDArray<T, D> {
         val data = initMemoryView<T>(this.size, this.dtype)
         var index = 0
         for (el in this)
             data[index++] = el
-        return Ndarray<T, D>(data, 0, this.shape.copyOf(), dtype = this.dtype, dim = this.dim)
+        return NDArray<T, D>(data, 0, this.shape.copyOf(), dtype = this.dtype, dim = this.dim)
     }
 
     override fun flatten(): MultiArray<T, D1> {
@@ -139,7 +139,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
         }
     }
 
-    override fun reshape(dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int): Ndarray<T, DN> {
+    override fun reshape(dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int): NDArray<T, DN> {
         val newShape = intArrayOf(dim1, dim2, dim3, dim4) + dims
         newShape.forEach { requirePositiveShape(it) }
         require(newShape.fold(1, Int::times) == size) {
@@ -147,13 +147,13 @@ public class Ndarray<T : Number, D : Dimension> constructor(
         }
 
         return if (this.shape.contentEquals(newShape)) {
-            this as Ndarray<T, DN>
+            this as NDArray<T, DN>
         } else {
-            Ndarray<T, DN>(this.data, this.offset, newShape, dtype = this.dtype, dim = DN(newShape.size))
+            NDArray<T, DN>(this.data, this.offset, newShape, dtype = this.dtype, dim = DN(newShape.size))
         }
     }
 
-    override fun transpose(vararg axes: Int): Ndarray<T, D> {
+    override fun transpose(vararg axes: Int): NDArray<T, D> {
         val newShape: IntArray
         val newStrides: IntArray
         if (axes.isEmpty()) {
@@ -167,10 +167,10 @@ public class Ndarray<T : Number, D : Dimension> constructor(
                 newStrides[i] = this.strides[axis]
             }
         }
-        return Ndarray(this.data, this.offset, newShape, newStrides, this.dtype, this.dim)
+        return NDArray(this.data, this.offset, newShape, newStrides, this.dtype, this.dim)
     }
 
-    override fun squeeze(vararg axes: Int): Ndarray<T, DN> {
+    override fun squeeze(vararg axes: Int): NDArray<T, DN> {
         val cutAxes = if (axes.isEmpty()) {
             shape.withIndex().filter { it.value == 1 }.map { it.index }
         } else {
@@ -178,15 +178,15 @@ public class Ndarray<T : Number, D : Dimension> constructor(
             axes.toList()
         }
         val newShape = this.shape.sliceArray(this.shape.indices - cutAxes)
-        return Ndarray<T, DN>(this.data, this.offset, newShape, dtype = this.dtype, dim = DN(newShape.size))
+        return NDArray<T, DN>(this.data, this.offset, newShape, dtype = this.dtype, dim = DN(newShape.size))
     }
 
-    override fun unsqueeze(vararg axes: Int): Ndarray<T, DN> {
+    override fun unsqueeze(vararg axes: Int): NDArray<T, DN> {
         val newShape = shape.toMutableList()
         for (axis in axes.sorted()) {
             newShape.add(axis, 1)
         }
-        return Ndarray<T, DN>(
+        return NDArray<T, DN>(
             this.data,
             this.offset,
             newShape.toIntArray(),
@@ -195,7 +195,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
         )
     }
 
-    override fun cat(other: MultiArray<T, D>, axis: Int): Ndarray<T, DN> {
+    override fun cat(other: MultiArray<T, D>, axis: Int): NDArray<T, DN> {
         require(
             this.shape.withIndex()
                 .all { it.index == axis || it.value == other.shape[it.index] }) { "All dimensions of input arrays for the concatenation axis must match exactly." }
@@ -206,7 +206,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
         val thisIt = this.iterator()
         val otherIt = other.iterator()
         var index = 0
-        val ret = Ndarray<T, DN>(
+        val ret = NDArray<T, DN>(
             initMemoryView(newShape.fold(1, Int::times), this.dtype),
             0,
             newShape,
@@ -223,37 +223,37 @@ public class Ndarray<T : Number, D : Dimension> constructor(
     //todo extensions
     public fun asD1Array(): D1Array<T> {
         if (this.dim.d == 1) return this as D1Array<T>
-        else throw ClassCastException("Cannot cast Ndarray of dimension ${this.dim.d} to Ndarray of dimension 1.")
+        else throw ClassCastException("Cannot cast NDArray of dimension ${this.dim.d} to NDArray of dimension 1.")
     }
 
     //todo
     public fun asD2Array(): D2Array<T> {
         if (this.dim.d == 2) return this as D2Array<T>
-        else throw ClassCastException("Cannot cast Ndarray of dimension ${this.dim.d} to Ndarray of dimension 2.")
+        else throw ClassCastException("Cannot cast NDArray of dimension ${this.dim.d} to NDArray of dimension 2.")
     }
 
     public fun asD3Array(): D3Array<T> {
         if (this.dim.d == 3) return this as D3Array<T>
-        else throw ClassCastException("Cannot cast Ndarray of dimension ${this.dim.d} to Ndarray of dimension 3.")
+        else throw ClassCastException("Cannot cast NDArray of dimension ${this.dim.d} to NDArray of dimension 3.")
     }
 
     public fun asD4Array(): D4Array<T> {
         if (this.dim.d == 4) return this as D4Array<T>
-        else throw ClassCastException("Cannot cast Ndarray of dimension ${this.dim.d} to Ndarray of dimension 4.")
+        else throw ClassCastException("Cannot cast NDArray of dimension ${this.dim.d} to NDArray of dimension 4.")
     }
 
-    public fun asDNArray(): Ndarray<T, DN> {
+    public fun asNDArray(): NDArray<T, DN> {
         if (this.dim.d == -1) throw Exception("Array dimension is undefined")
-        if (this.dim.d > 4) return this as Ndarray<T, DN>
+        if (this.dim.d > 4) return this as NDArray<T, DN>
 
-        return Ndarray(this.data, this.offset, this.shape, this.strides, this.dtype, DN(this.dim.d))
+        return NDArray(this.data, this.offset, this.shape, this.strides, this.dtype, DN(this.dim.d))
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as Ndarray<*, *>
+        other as NDArray<*, *>
 
         if (size != other.size) return false
         if (!shape.contentEquals(other.shape)) return false
@@ -281,10 +281,10 @@ public class Ndarray<T : Number, D : Dimension> constructor(
     override fun toString(): String {
         return when (dim.d) {
             1 -> buildString {
-                this@Ndarray as Ndarray<T, D1>
+                this@NDArray as NDArray<T, D1>
                 append('[')
                 for (i in 0 until shape.first()) {
-                    append(this@Ndarray[i])
+                    append(this@NDArray[i])
                     if (i < shape.first() - 1)
                         append(", ")
                 }
@@ -292,12 +292,12 @@ public class Ndarray<T : Number, D : Dimension> constructor(
             }
 
             2 -> buildString {
-                this@Ndarray as Ndarray<T, D2>
+                this@NDArray as NDArray<T, D2>
                 append('[')
                 for (ax0 in 0 until shape[0]) {
                     append('[')
                     for (ax1 in 0 until shape[1]) {
-                        append(this@Ndarray[ax0, ax1])
+                        append(this@NDArray[ax0, ax1])
                         if (ax1 < shape[1] - 1)
                             append(", ")
                     }
@@ -309,14 +309,14 @@ public class Ndarray<T : Number, D : Dimension> constructor(
             }
 
             3 -> buildString {
-                this@Ndarray as Ndarray<T, D3>
+                this@NDArray as NDArray<T, D3>
                 append('[')
                 for (ax0 in 0 until shape[0]) {
                     append('[')
                     for (ax1 in 0 until shape[1]) {
                         append('[')
                         for (ax2 in 0 until shape[2]) {
-                            append(this@Ndarray[ax0, ax1, ax2])
+                            append(this@NDArray[ax0, ax1, ax2])
                             if (ax2 < shape[2] - 1)
                                 append(", ")
                         }
@@ -332,7 +332,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
             }
 
             4 -> buildString {
-                this@Ndarray as Ndarray<T, D4>
+                this@NDArray as NDArray<T, D4>
                 append('[')
                 for (ax0 in 0 until shape[0]) {
                     append('[')
@@ -341,7 +341,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
                         for (ax2 in 0 until shape[2]) {
                             append('[')
                             for (ax3 in 0 until shape[3]) {
-                                append(this@Ndarray[ax0, ax1, ax2, ax3])
+                                append(this@NDArray[ax0, ax1, ax2, ax3])
                                 if (ax3 < shape[3] - 1)
                                     append(", ")
                             }
@@ -361,10 +361,10 @@ public class Ndarray<T : Number, D : Dimension> constructor(
             }
 
             else -> buildString {
-                this@Ndarray as Ndarray<*, DN>
+                this@NDArray as NDArray<*, DN>
                 append('[')
                 for (ind in 0 until shape.first()) {
-                    append(this@Ndarray.V[ind].toString())
+                    append(this@NDArray.V[ind].toString())
                     if (ind < shape.first() - 1) {
                         val newLine = "\n".repeat(dim.d - 1)
                         append(",$newLine")

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/NDArrayIterator.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/NDArrayIterator.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.multik.ndarray.data
 /**
  * Iterator over multidimensional arrays. Iterated taking into account the [offset], [strides] and [shape].
  */
-public class NdarrayIterator<T : Number>(
+public class NDArrayIterator<T : Number>(
     private val data: MemoryView<T>,
     private val offset: Int = 0,
     private val strides: IntArray,

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/Ndarray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/Ndarray.kt
@@ -70,7 +70,7 @@ public class Ndarray<T : Number, D : Dimension> constructor(
     override fun clone(): Ndarray<T, D> =
         Ndarray(this.data.copyOf(), this.offset, this.shape.copyOf(), this.strides.copyOf(), this.dtype, this.dim)
 
-    override fun deepCope(): Ndarray<T, D> {
+    override fun deepCopy(): Ndarray<T, D> {
         val data = initMemoryView<T>(this.size, this.dtype)
         var index = 0
         for (el in this)

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/ArithmeticNDArray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/ArithmeticNDArray.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlinx.multik.ndarray.data.*
 /**
  * Create a new array as the sum of [this] and [other].
  */
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.plus(other: MultiArray<T, D>): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.plus(other: MultiArray<T, D>): NDArray<T, D> {
     requireArraySizes(this.size, other.size)
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
@@ -17,16 +17,16 @@ public operator fun <T : Number, D : Dimension> MultiArray<T, D>.plus(other: Mul
     for (i in this.indices) {
         data[i] = iterLeft.next() + iterRight.next()
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.plus(other: T): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.plus(other: T): NDArray<T, D> {
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
     for (i in this.indices) {
         data[i] = iterLeft.next() + other
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
 /**
@@ -40,7 +40,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.plusAssi
         for (i in this.indices)
             this[i] += other[i]
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         val iterRight = other.iterator()
         for (index in this.multiIndices)
             left[index] += iterRight.next()
@@ -58,7 +58,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.plusAssi
         for (i in this.indices)
             this[i] += other
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         for (index in this.multiIndices)
             left[index] += other
     }
@@ -68,7 +68,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.plusAssi
 /**
  * Create a new array as difference between [this] and [other].
  */
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.minus(other: MultiArray<T, D>): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.minus(other: MultiArray<T, D>): NDArray<T, D> {
     requireArraySizes(this.size, other.size)
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
@@ -76,16 +76,16 @@ public operator fun <T : Number, D : Dimension> MultiArray<T, D>.minus(other: Mu
     for (i in this.indices) {
         data[i] = iterLeft.next() - iterRight.next()
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.minus(other: T): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.minus(other: T): NDArray<T, D> {
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
     for (i in this.indices) {
         data[i] = iterLeft.next() - other
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
 /**
@@ -99,7 +99,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.minusAss
         for (i in this.indices)
             this[i] -= other[i]
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         val iterRight = other.iterator()
         for (index in this.multiIndices)
             left[index] -= iterRight.next()
@@ -115,7 +115,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.minusAss
         for (i in this.indices)
             this[i] -= other
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         for (index in this.multiIndices)
             left[index] -= other
     }
@@ -124,7 +124,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.minusAss
 /**
  * Create a new array as product of [this] and [other].
  */
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.times(other: MultiArray<T, D>): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.times(other: MultiArray<T, D>): NDArray<T, D> {
     requireArraySizes(this.size, other.size)
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
@@ -132,16 +132,16 @@ public operator fun <T : Number, D : Dimension> MultiArray<T, D>.times(other: Mu
     for (i in this.indices) {
         data[i] = iterLeft.next() * iterRight.next()
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.times(other: T): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.times(other: T): NDArray<T, D> {
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
     for (i in this.indices) {
         data[i] = iterLeft.next() * other
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
 /**
@@ -155,7 +155,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.timesAss
         for (i in this.indices)
             this[i] *= other[i]
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         val iterRight = other.iterator()
         for (index in this.multiIndices)
             left[index] *= iterRight.next()
@@ -171,7 +171,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.timesAss
         for (i in this.indices)
             this[i] *= other
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         for (index in this.multiIndices)
             left[index] *= other
     }
@@ -180,7 +180,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.timesAss
 /**
  * Create a new array as division of [this] by [other].
  */
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.div(other: MultiArray<T, D>): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.div(other: MultiArray<T, D>): NDArray<T, D> {
     requireArraySizes(this.size, other.size)
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
@@ -188,16 +188,16 @@ public operator fun <T : Number, D : Dimension> MultiArray<T, D>.div(other: Mult
     for (i in this.indices) {
         data[i] = iterLeft.next() / iterRight.next()
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
-public operator fun <T : Number, D : Dimension> MultiArray<T, D>.div(other: T): Ndarray<T, D> {
+public operator fun <T : Number, D : Dimension> MultiArray<T, D>.div(other: T): NDArray<T, D> {
     val data = initMemoryView<T>(size, dtype)
     val iterLeft = this.iterator()
     for (i in this.indices) {
         data[i] = iterLeft.next() / other
     }
-    return Ndarray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
+    return NDArray<T, D>(data, shape = shape.copyOf(), dtype = dtype, dim = dim)
 }
 
 /**
@@ -211,7 +211,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.divAssig
         for (i in this.indices)
             this[i] /= other[i]
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         val iterRight = other.iterator()
         for (index in this.multiIndices)
             left[index] /= iterRight.next()
@@ -227,7 +227,7 @@ public operator fun <T : Number, D : Dimension> MutableMultiArray<T, D>.divAssig
         for (i in this.indices)
             this[i] /= other
     } else {
-        val left = this.asDNArray()
+        val left = this.asNDArray()
         for (index in this.multiIndices)
             left[index] /= other
     }

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/Inplace.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/Inplace.kt
@@ -9,7 +9,7 @@ import kotlin.math.*
 
 private fun unsupported(): Nothing = throw UnsupportedOperationException("Not supported for local property reference.")
 
-public fun <T : Number, D : Dimension> Ndarray<T, D>.inplace(init: InplaceOperation<T, D>.() -> Unit): Unit {
+public fun <T : Number, D : Dimension> NDArray<T, D>.inplace(init: InplaceOperation<T, D>.() -> Unit): Unit {
     val inplaceOperation = InplaceOperation(this)
     inplaceOperation.init()
 }

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/IteratingNDArray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/IteratingNDArray.kt
@@ -6,7 +6,7 @@ package org.jetbrains.kotlinx.multik.ndarray.operations
 
 import org.jetbrains.kotlinx.multik.api.mk
 import org.jetbrains.kotlinx.multik.api.ndarray
-import org.jetbrains.kotlinx.multik.api.toNdarray
+import org.jetbrains.kotlinx.multik.api.toNDArray
 import org.jetbrains.kotlinx.multik.ndarray.data.*
 import kotlin.math.abs
 import kotlin.math.min
@@ -14,7 +14,7 @@ import kotlin.math.min
 
 /**
  * Returns `true` if all elements match the given [predicate].
- * If a ndarray is empty, then always returns `true`.
+ * If an ndarray is empty, then always returns `true`.
  */
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.all(predicate: (T) -> Boolean): Boolean {
     if (isEmpty()) return true
@@ -24,7 +24,7 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.all(predicate: (T
 
 /**
  * Returns `true` if collection has at least one element.
- * @see Ndarray.isNotEmpty
+ * @see NDArray.isNotEmpty
  */
 public fun <T : Number, D : Dimension> MultiArray<T, D>.any(): Boolean {
     return isNotEmpty()
@@ -32,7 +32,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.any(): Boolean {
 
 /**
  * Returns `true` if at least one element matches the given [predicate].
- * If a ndarray is empty, then always returns `false`.
+ * If an ndarray is empty, then always returns `false`.
  */
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.any(predicate: (T) -> Boolean): Boolean {
     if (isEmpty()) return false
@@ -177,7 +177,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.average(): Double {
  *
  * @param size number of elements in axis 1.
  */
-public fun <T : Number, D : Dimension> MultiArray<T, D>.chunked(size: Int): Ndarray<T, D2> {
+public fun <T : Number, D : Dimension> MultiArray<T, D>.chunked(size: Int): NDArray<T, D2> {
     return windowed(size, size, limit = false)
 }
 
@@ -189,7 +189,7 @@ public operator fun <T : Number, D : Dimension> MultiArray<T, D>.contains(elemen
 }
 
 /**
- * Returns the number of elements in a ndarray.
+ * Returns the number of elements in an ndarray.
  */
 @Suppress("NOTHING_TO_INLINE")
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.count(): Int {
@@ -209,15 +209,15 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.count(predicate: 
 /**
  * Returns a new array containing only distinct elements from the given array.
  */
-public fun <T : Number, D : Dimension> MultiArray<T, D>.distinct(): Ndarray<T, D1> {
-    return this.toMutableSet().toNdarray()
+public fun <T : Number, D : Dimension> MultiArray<T, D>.distinct(): NDArray<T, D1> {
+    return this.toMutableSet().toNDArray()
 }
 
 /**
  * Returns a new array containing only elements from the given array
  * having distinct keys returned by the given [selector] function.
  */
-public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.distinctBy(selector: (T) -> K): Ndarray<T, D1> {
+public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.distinctBy(selector: (T) -> K): NDArray<T, D1> {
     val set = HashSet<K>()
     val list = ArrayList<T>()
     for (e in this) {
@@ -225,7 +225,7 @@ public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.distinctBy(sel
         if (set.add(key))
             list.add(e)
     }
-    return list.toNdarray()
+    return list.toNDArray()
 }
 
 /**
@@ -244,7 +244,7 @@ public fun <T : Number> MultiArray<T, D1>.drop(n: Int): D1Array<T> {
 /**
  * Drops elements that don't satisfy the [predicate].
  */
-public inline fun <T : Number> MultiArray<T, D1>.dropWhile(predicate: (T) -> Boolean): Ndarray<T, D1> {
+public inline fun <T : Number> MultiArray<T, D1>.dropWhile(predicate: (T) -> Boolean): NDArray<T, D1> {
     var yielding = false
     val list = ArrayList<T>()
     for (item in this)
@@ -263,7 +263,7 @@ public inline fun <T : Number> MultiArray<T, D1>.dropWhile(predicate: (T) -> Boo
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.filter(predicate: (T) -> Boolean): D1Array<T> {
     val list = ArrayList<T>()
     forEach { if (predicate(it)) list.add(it) }
-    return list.toNdarray()
+    return list.toNDArray()
 }
 
 /**
@@ -273,7 +273,7 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.filter(predicate:
 public inline fun <T : Number> MultiArray<T, D1>.filterIndexed(predicate: (index: Int, T) -> Boolean): D1Array<T> {
     val list = ArrayList<T>()
     forEachIndexed { index: Int, element -> if (predicate(index, element)) list.add(element) }
-    return list.toNdarray()
+    return list.toNDArray()
 }
 
 
@@ -284,7 +284,7 @@ public inline fun <T : Number> MultiArray<T, D1>.filterIndexed(predicate: (index
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.filterIndexed(predicate: (index: IntArray, T) -> Boolean): D1Array<T> {
     val list = ArrayList<T>()
     forEachIndexed { index: IntArray, element -> if (predicate(index, element)) list.add(element) }
-    return list.toNdarray()
+    return list.toNDArray()
 }
 
 /**
@@ -293,7 +293,7 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.filterIndexed(pre
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.filterNot(predicate: (T) -> Boolean): D1Array<T> {
     val list = ArrayList<T>()
     for (element in this) if (!predicate(element)) list.add(element)
-    return list.toNdarray()
+    return list.toNDArray()
 }
 
 /**
@@ -315,7 +315,7 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.findLast(predicat
  * @throws [NoSuchElementException] if the collection is empty.
  */
 public fun <T : Number, D : Dimension> MultiArray<T, D>.first(): T {
-    if (isEmpty()) throw NoSuchElementException("Ndarray is empty.")
+    if (isEmpty()) throw NoSuchElementException("NDArray is empty.")
     return this.data[this.offset]
 }
 
@@ -325,7 +325,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.first(): T {
  */
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.first(predicate: (T) -> Boolean): T {
     for (element in this) if (predicate(element)) return element
-    throw NoSuchElementException("Ndarray contains no element matching the predicate.")
+    throw NoSuchElementException("NDArray contains no element matching the predicate.")
 }
 
 /**
@@ -353,7 +353,7 @@ public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, 
         val list = transform(element)
         destination.addAll(list)
     }
-    return destination.toNdarray()
+    return destination.toNDArray()
 }
 
 /**
@@ -368,7 +368,7 @@ public inline fun <T : Number, reified R : Number> MultiArray<T, D1>.flatMapInde
         val list = transform(checkIndexOverflow(index++), element)
         destination.addAll(list)
     }
-    return destination.toNdarray()
+    return destination.toNDArray()
 }
 
 /**
@@ -387,7 +387,7 @@ public inline fun <T : Number, reified R : Number> MultiArray<T, D1>.flatMapInde
             throw ArithmeticException("Index overflow has happened.")
         }
     }
-    return destination.toNdarray()
+    return destination.toNDArray()
 }
 
 
@@ -474,28 +474,28 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.forEachIndexed(ac
 
 /**
  * Groups elements of a given ndarray by the key returned by [keySelector] for each element,
- * and returns a map where each group key is associated with a ndarray of matching elements.
+ * and returns a map where each group key is associated with an ndarray of matching elements.
  */
-public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.groupNdarrayBy(keySelector: (T) -> K): Map<K, Ndarray<T, D1>> {
-    return groupNdarrayByTo(LinkedHashMap<K, Ndarray<T, D1>>(), keySelector)
+public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.groupNDArrayBy(keySelector: (T) -> K): Map<K, NDArray<T, D1>> {
+    return groupNDArrayByTo(LinkedHashMap<K, NDArray<T, D1>>(), keySelector)
 }
 
 /**
  * Groups values returned by [valueTransform] applied to each element of the given ndarray
  * with the key returned by [keySelector] applied to each element,
- * and returns a map where each group key is associated with a ndarray of matching values.
+ * and returns a map where each group key is associated with an ndarray of matching values.
  */
-public inline fun <T : Number, D : Dimension, K, V : Number> MultiArray<T, D>.groupNdarrayBy(
+public inline fun <T : Number, D : Dimension, K, V : Number> MultiArray<T, D>.groupNDArrayBy(
     keySelector: (T) -> K, valueTransform: (T) -> V
-): Map<K, Ndarray<V, D1>> {
-    return groupNdarrayByTo(LinkedHashMap<K, Ndarray<V, D1>>(), keySelector, valueTransform)
+): Map<K, NDArray<V, D1>> {
+    return groupNDArrayByTo(LinkedHashMap<K, NDArray<V, D1>>(), keySelector, valueTransform)
 }
 
 /**
  * Groups elements of the given array by the key returned by [keySelector] function applied to each
- * element and puts to the [destination] map each group key associated with a ndarray of corresponding elements.
+ * element and puts to the [destination] map each group key associated with an ndarray of corresponding elements.
  */
-public inline fun <T : Number, D : Dimension, K, M : MutableMap<in K, Ndarray<T, D1>>> MultiArray<T, D>.groupNdarrayByTo(
+public inline fun <T : Number, D : Dimension, K, M : MutableMap<in K, NDArray<T, D1>>> MultiArray<T, D>.groupNDArrayByTo(
     destination: M, keySelector: (T) -> K
 ): M {
     val map = LinkedHashMap<K, MutableList<T>>()
@@ -505,16 +505,16 @@ public inline fun <T : Number, D : Dimension, K, M : MutableMap<in K, Ndarray<T,
         list.add(element)
     }
     for (item in map)
-        destination.put(item.key, item.value.toNdarray())
+        destination.put(item.key, item.value.toNDArray())
     return destination
 }
 
 /**
  * Groups values returned by the [valueTransform] function applied to each element of the given ndarray by the key
  * returned by [keySelector] function applied to the element and puts to the destination map each group key
- * associated with a ndarray of corresponding values.
+ * associated with an ndarray of corresponding values.
  */
-public inline fun <T : Number, D : Dimension, K, V : Number, M : MutableMap<in K, Ndarray<V, D1>>> MultiArray<T, D>.groupNdarrayByTo(
+public inline fun <T : Number, D : Dimension, K, V : Number, M : MutableMap<in K, NDArray<V, D1>>> MultiArray<T, D>.groupNDArrayByTo(
     destination: M, keySelector: (T) -> K, valueTransform: (T) -> V
 ): M {
     val map = LinkedHashMap<K, MutableList<V>>()
@@ -524,17 +524,17 @@ public inline fun <T : Number, D : Dimension, K, V : Number, M : MutableMap<in K
         list.add(valueTransform(element))
     }
     for (item in map)
-        destination.put(item.key, item.value.toNdarray())
+        destination.put(item.key, item.value.toNDArray())
     return destination
 }
 
 /**
- * Creates a [Grouping] source from a ndarray to be used later with one of group-and-fold operations using the
+ * Creates a [Grouping] source from an ndarray to be used later with one of group-and-fold operations using the
  * specified [keySelector] function to extract a key from each element.
  */
-public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.groupingNdarrayBy(crossinline keySelector: (T) -> K): Grouping<T, K> {
+public inline fun <T : Number, D : Dimension, K> MultiArray<T, D>.groupingNDArrayBy(crossinline keySelector: (T) -> K): Grouping<T, K> {
     return object : Grouping<T, K> {
-        override fun sourceIterator(): Iterator<T> = this@groupingNdarrayBy.iterator()
+        override fun sourceIterator(): Iterator<T> = this@groupingNDArrayBy.iterator()
         override fun keyOf(element: T): K = keySelector(element)
     }
 }
@@ -641,9 +641,9 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.joinToString(
  * @throws [NoSuchElementException] if the collection is empty.
  */
 public fun <T : Number, D : Dimension> MultiArray<T, D>.last(): T {
-    if (isEmpty()) throw NoSuchElementException("Ndarray is empty.")
+    if (isEmpty()) throw NoSuchElementException("NDArray is empty.")
     val index = IntArray(dim.d) { shape[it] - 1 }
-    return this.asDNArray()[index]
+    return this.asNDArray()[index]
 }
 
 
@@ -652,12 +652,12 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.last(): T {
  * @throws [NoSuchElementException] if no such element is found.
  */
 public inline fun <T : Number, D : Dimension> MultiArray<T, D>.last(predicate: (T) -> Boolean): T {
-    val ndarray = this.asDNArray()
+    val ndarray = this.asNDArray()
     for (i in this.multiIndices.reverse) {
         val element = ndarray[i]
         if (predicate(element)) return element
     }
-    throw NoSuchElementException("Ndarray contains no element matching the predicate.")
+    throw NoSuchElementException("NDArray contains no element matching the predicate.")
 }
 
 /**
@@ -679,7 +679,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.lastIndexOf(element: T):
  * Returns the last element, or `null` if the list is empty.
  */
 public fun <T : Number, D : Dimension> MultiArray<T, D>.lastOrNull(): T? {
-    return if (isEmpty()) null else this.asDNArray()[this.multiIndices.last]
+    return if (isEmpty()) null else this.asNDArray()[this.multiIndices.last]
 }
 
 /**
@@ -699,14 +699,14 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.lastOrNull(predic
 /**
  * Return a new array contains elements after applying [transform].
  */
-public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.map(transform: (T) -> R): Ndarray<R, D> {
+public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.map(transform: (T) -> R): NDArray<R, D> {
     val newDtype = DataType.of(R::class)
     val data = initMemoryView<R>(size, newDtype)
-    val op = this.asDNArray()
+    val op = this.asNDArray()
     var count = 0
     for (i in this.multiIndices)
         data[count++] = transform(op[i])
-    return Ndarray<R, D>(data, shape = shape, dtype = newDtype, dim = dim)
+    return NDArray<R, D>(data, shape = shape, dtype = newDtype, dim = dim)
 }
 
 /**
@@ -726,7 +726,7 @@ public inline fun <T : Number, reified R : Number> MultiArray<T, D1>.mapIndexed(
  * Return a new array contains elements after applying [transform].
  */
 @JvmName("mapDNIndexed")
-public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.mapIndexed(transform: (index: IntArray, T) -> R): Ndarray<R, D> {
+public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.mapIndexed(transform: (index: IntArray, T) -> R): NDArray<R, D> {
     val newDtype = DataType.of(R::class)
     val data = initMemoryView<R>(size, newDtype)
     val indexIter = this.multiIndices.iterator()
@@ -738,7 +738,7 @@ public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, 
             throw ArithmeticException("Index overflow has happened.")
         }
     }
-    return Ndarray<R, D>(data, shape = shape, dtype = newDtype, dim = dim)
+    return NDArray<R, D>(data, shape = shape, dtype = newDtype, dim = dim)
 }
 
 /**
@@ -757,23 +757,23 @@ public inline fun <T : Number, reified R : Number> MultiArray<T, D1>.mapIndexedN
  * Return a new array contains elements after applying [transform].
  */
 @JvmName("mapDNIndexedNotNull")
-public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.mapIndexedNotNull(transform: (index: IntArray, T) -> R?): Ndarray<R, D> {
+public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.mapIndexedNotNull(transform: (index: IntArray, T) -> R?): NDArray<R, D> {
     val newDtype = DataType.of(R::class)
     val data = initMemoryView<R>(size, newDtype)
     var count = 0
     forEachIndexed { index, element -> transform(index, element)?.let { data[count++] = it } }
-    return Ndarray<R, D>(data, shape = shape.copyOf(), dtype = newDtype, dim = dim)
+    return NDArray<R, D>(data, shape = shape.copyOf(), dtype = newDtype, dim = dim)
 }
 
 /**
  * Return a new array contains elements after applying [transform].
  */
-public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.mapNotNull(transform: (T) -> R?): Ndarray<R, D> {
+public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.mapNotNull(transform: (T) -> R?): NDArray<R, D> {
     val newDtype = DataType.of(R::class)
     val data = initMemoryView<R>(size, newDtype)
     var index = 0
     forEach { element -> transform(element)?.let { data[index++] = it } }
-    return Ndarray<R, D>(data, shape = shape, dtype = newDtype, dim = dim)
+    return NDArray<R, D>(data, shape = shape, dtype = newDtype, dim = dim)
 }
 
 /**
@@ -884,7 +884,7 @@ public inline fun <T : Number, D : Dimension, C : MultiArray<T, D>> C.onEach(act
  * where *first* list contains elements for which [predicate] yielded `true`,
  * while *second* list contains elements for which [predicate] yielded `false`.
  */
-public inline fun <T : Number, D : Dimension> MultiArray<T, D>.partition(predicate: (T) -> Boolean): Pair<Ndarray<T, D1>, Ndarray<T, D1>> {
+public inline fun <T : Number, D : Dimension> MultiArray<T, D>.partition(predicate: (T) -> Boolean): Pair<NDArray<T, D1>, NDArray<T, D1>> {
     val first = ArrayList<T>()
     val second = ArrayList<T>()
     for (element in this) {
@@ -894,7 +894,7 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.partition(predica
             second.add(element)
         }
     }
-    return Pair(first.toNdarray(), second.toNdarray())
+    return Pair(first.toNDArray(), second.toNDArray())
 }
 
 /**
@@ -909,7 +909,7 @@ public inline fun <T : Number, D : Dimension> MultiArray<T, D>.partition(predica
  */
 public fun <T : Number, D : Dimension> MultiArray<T, D>.windowed(
     size: Int, step: Int = 1, limit: Boolean = true
-): Ndarray<T, D2> {
+): NDArray<T, D2> {
     require(size > 0 && step > 0) {
         if (size != step)
             "Both size $size and step $step must be greater than zero."
@@ -926,7 +926,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.windowed(
         else -> (thisSize / rStep + 1) * rSize
     }
     val resData = initMemoryView<T>(resultCapacity, this.dtype)
-    val thisNdarray = this.flatten()
+    val thisNDArray = this.flatten()
     var index = 0
     var resIndex = 0
     while (index in 0 until thisSize) {
@@ -935,7 +935,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.windowed(
                 resIndex++
                 continue
             }
-            resData[resIndex++] = thisNdarray[i + index]
+            resData[resIndex++] = thisNDArray[i + index]
         }
         index += rStep
     }
@@ -1007,13 +1007,13 @@ public inline fun <S : Number, D : Dimension, T : S> MultiArray<T, D>.reduceOrNu
 /**
  *
  */
-public fun <T : Number, D : Dimension> MultiArray<T, D>.reversed(): Ndarray<T, D> {
-    if (size <= 1) return this.clone() as Ndarray<T, D>
+public fun <T : Number, D : Dimension> MultiArray<T, D>.reversed(): NDArray<T, D> {
+    if (size <= 1) return this.clone() as NDArray<T, D>
     val data = initMemoryView<T>(this.size, this.dtype)
     var index = this.size - 1
     for (element in this)
         data[index--] = element
-    return Ndarray<T, D>(data, 0, this.shape.copyOf(), dtype = this.dtype, dim = this.dim)
+    return NDArray<T, D>(data, 0, this.shape.copyOf(), dtype = this.dtype, dim = this.dim)
 }
 
 
@@ -1028,7 +1028,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.reversed(): Ndarray<T, D
  */
 public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.scan(
     initial: R, operation: (acc: R, T) -> R
-): Ndarray<R, D> {
+): NDArray<R, D> {
     val dataType = DataType.of(R::class)
     val data = initMemoryView<R>(this.size + 1, dataType)
     data[0] = initial
@@ -1038,7 +1038,7 @@ public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, 
         accumulator = operation(accumulator, element)
         data[index++] = accumulator
     }
-    return Ndarray<R, D>(data, 0, this.shape.copyOf(), dtype = dataType, dim = this.dim)
+    return NDArray<R, D>(data, 0, this.shape.copyOf(), dtype = dataType, dim = this.dim)
 }
 
 /**
@@ -1069,7 +1069,7 @@ public inline fun <T : Number, reified R : Number> MultiArray<T, D1>.scanIndexed
  */
 public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, D>.scanIndexed(
     initial: R, operation: (index: IntArray, acc: R, T) -> R
-): Ndarray<R, D> {
+): NDArray<R, D> {
     val dataType = DataType.of(R::class)
     val data = initMemoryView<R>(this.size + 1, dataType)
     data[0] = initial
@@ -1081,14 +1081,14 @@ public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, 
         accumulator = operation(indexIter.next(), accumulator, ndarrayIter.next())
         data[count++] = accumulator
     }
-    return Ndarray<R, D>(data, 0, this.shape.copyOf(), dtype = dataType, dim = this.dim)
+    return NDArray<R, D>(data, 0, this.shape.copyOf(), dtype = dataType, dim = this.dim)
 }
 
 /**
  *
  */
-public fun <T : Number, D : Dimension> MultiArray<T, D>.sorted(): Ndarray<T, D> {
-    val ret = this.deepCopy() as Ndarray<T, D>
+public fun <T : Number, D : Dimension> MultiArray<T, D>.sorted(): NDArray<T, D> {
+    val ret = this.deepCopy() as NDArray<T, D>
     when (this.dtype) {
         DataType.ByteDataType -> ret.data.getByteArray().sort()
         DataType.ShortDataType -> ret.data.getShortArray().sort()

--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/IteratingNdarray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/IteratingNdarray.kt
@@ -1088,7 +1088,7 @@ public inline fun <T : Number, D : Dimension, reified R : Number> MultiArray<T, 
  *
  */
 public fun <T : Number, D : Dimension> MultiArray<T, D>.sorted(): Ndarray<T, D> {
-    val ret = this.deepCope() as Ndarray<T, D>
+    val ret = this.deepCopy() as Ndarray<T, D>
     when (this.dtype) {
         DataType.ByteDataType -> ret.data.getByteArray().sort()
         DataType.ShortDataType -> ret.data.getShortArray().sort()

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray1DTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray1DTest.kt
@@ -7,7 +7,7 @@ package org.jetbrains.kotlinx.multik.creation
 import org.jetbrains.kotlinx.multik.api.*
 import org.jetbrains.kotlinx.multik.ndarray.data.D1
 import org.jetbrains.kotlinx.multik.ndarray.data.DataType
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.operations.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -106,14 +106,14 @@ class CreateArray1DTest {
 
     @Test
     fun createArrayFromCollectionTest() {
-        val a: Ndarray<Int, D1> = mk.ndarray(setOf(1, 2, 3), intArrayOf(3))
-        val b: Ndarray<Int, D1> = mk.ndarray(arrayListOf(1, 2, 3), intArrayOf(3))
+        val a: NDArray<Int, D1> = mk.ndarray(setOf(1, 2, 3), intArrayOf(3))
+        val b: NDArray<Int, D1> = mk.ndarray(arrayListOf(1, 2, 3), intArrayOf(3))
         assertEquals(a, b)
     }
 
     @Test
     fun createArrayFromIntRangeTest() {
-        val a = (0..9).toNdarray()
+        val a = (0..9).toNDArray()
         val b = mk.d1array(10) { it }
         assertEquals(a, b)
     }

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray2DTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray2DTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlinx.multik.api.d2array
 import org.jetbrains.kotlinx.multik.api.mk
 import org.jetbrains.kotlinx.multik.api.ndarray
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.operations.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -90,8 +90,8 @@ class CreateArray2DTest {
     @Test
     fun createArrayFromCollectionTest() {
         val shapeCol = intArrayOf(2, 3)
-        val a: Ndarray<Int, D2> = mk.ndarray(setOf(0, 2, 3, 32, 5, 7), shapeCol)
-        val b: Ndarray<Int, D2> = mk.ndarray(arrayListOf(0, 2, 3, 32, 5, 7), shapeCol)
+        val a: NDArray<Int, D2> = mk.ndarray(setOf(0, 2, 3, 32, 5, 7), shapeCol)
+        val b: NDArray<Int, D2> = mk.ndarray(arrayListOf(0, 2, 3, 32, 5, 7), shapeCol)
         assertEquals(a, b)
     }
 }

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray3DTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray3DTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlinx.multik.api.d3array
 import org.jetbrains.kotlinx.multik.api.mk
 import org.jetbrains.kotlinx.multik.api.ndarray
 import org.jetbrains.kotlinx.multik.ndarray.data.D3
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.operations.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -93,8 +93,8 @@ class CreateArray3DTest {
         val shapeCol = intArrayOf(2, 3, 3)
         val l = Array(18) { it }.toList()
         val size_ = HashSet(l)
-        val a: Ndarray<Int, D3> = mk.ndarray(size_, shapeCol)
-        val b: Ndarray<Int, D3> = mk.ndarray(l, shapeCol)
+        val a: NDArray<Int, D3> = mk.ndarray(size_, shapeCol)
+        val b: NDArray<Int, D3> = mk.ndarray(l, shapeCol)
         assertEquals(a, b)
     }
 }

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray4DTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArray4DTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlinx.multik.api.d4array
 import org.jetbrains.kotlinx.multik.api.mk
 import org.jetbrains.kotlinx.multik.api.ndarray
 import org.jetbrains.kotlinx.multik.ndarray.data.D4
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.operations.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -93,8 +93,8 @@ class CreateArray4DTest {
         val shapeCol = intArrayOf(2, 3, 3, 2)
         val l = Array(36) { it }.toList()
         val size_ = HashSet(l)
-        val a: Ndarray<Int, D4> = mk.ndarray(size_, shapeCol)
-        val b: Ndarray<Int, D4> = mk.ndarray(l, shapeCol)
+        val a: NDArray<Int, D4> = mk.ndarray(size_, shapeCol)
+        val b: NDArray<Int, D4> = mk.ndarray(l, shapeCol)
         assertEquals(a, b)
     }
 }

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArrayNDTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/creation/CreateArrayNDTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlinx.multik.api.dnarray
 import org.jetbrains.kotlinx.multik.api.mk
 import org.jetbrains.kotlinx.multik.api.ndarray
 import org.jetbrains.kotlinx.multik.ndarray.data.DN
-import org.jetbrains.kotlinx.multik.ndarray.data.Ndarray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.operations.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -94,8 +94,8 @@ class CreateArrayNDTest {
         val shapeCol = intArrayOf(2, 3, 3, 2, 1)
         val l = Array(36) { it }.toList()
         val size_ = HashSet(l)
-        val a: Ndarray<Int, DN> = mk.ndarray(size_, shapeCol)
-        val b: Ndarray<Int, DN> = mk.ndarray(l, shapeCol)
+        val a: NDArray<Int, DN> = mk.ndarray(size_, shapeCol)
+        val b: NDArray<Int, DN> = mk.ndarray(l, shapeCol)
         assertEquals(a, b)
     }
 }

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/iterable/IterableNDArrayTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/iterable/IterableNDArrayTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class IterableNdarrayTest {
+class IterableNDArrayTest {
 
     @Test
     fun `test of function associate`() {
@@ -204,13 +204,13 @@ class IterableNdarrayTest {
     }
 
     @Test
-    fun `test groupNdarrayBy`() {
+    fun `test groupNDArrayBy`() {
         val data = mk.d3array(2, 2, 2) { it }
         val expected1 = mapOf(0 to mk.ndarrayOf(0, 2, 4, 6), 1 to mk.ndarrayOf(1, 3, 5, 7))
-        assertEquals(expected1, data.groupNdarrayBy { it % 2 })
+        assertEquals(expected1, data.groupNDArrayBy { it % 2 })
 
         val expected2 = mapOf(0 to mk.ndarrayOf(0f, 2f, 4f, 6f), 1 to mk.ndarrayOf(1f, 3f, 5f, 7f))
-        assertEquals(expected2, data.groupNdarrayBy({ it % 2 }, { it.toFloat() }))
+        assertEquals(expected2, data.groupNDArrayBy({ it % 2 }, { it.toFloat() }))
     }
 
     @Test
@@ -292,8 +292,8 @@ class IterableNdarrayTest {
     fun `test sort`() {
         val intArray = intArrayOf(42, 42, 23, 1, 23, 4, 10, 14, 3, 7, 25, 16, 2, 1, 37)
         val ndarray = mk.ndarray(intArray, 3, 5)
-        val sortedNdarray = ndarray.sorted()
-        sortedNdarray[2, 2] = 1000
+        val sortedNDArray = ndarray.sorted()
+        sortedNDArray[2, 2] = 1000
 
     }
 

--- a/multik-api/src/test/kotlin/samples/creation.kt
+++ b/multik-api/src/test/kotlin/samples/creation.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlinx.multik.ndarray.data.D3
 import org.jetbrains.kotlinx.multik.ndarray.data.DN
 import org.jetbrains.kotlinx.multik.ndarray.data.DataType
 
-class Ndarray {
+class NDArrayTest {
     @kotlin.test.Test
     fun empty() {
         val ndarray = mk.empty<Int, D2>(2, 2)
@@ -35,8 +35,8 @@ class Ndarray {
 
     @kotlin.test.Test
     fun identity() {
-        val identNdarray = mk.identity<Long>(3)
-        println(identNdarray)
+        val identNDArray = mk.identity<Long>(3)
+        println(identNDArray)
         /*
         [[1, 0, 0],
         [0, 1, 0],
@@ -46,8 +46,8 @@ class Ndarray {
 
     @kotlin.test.Test
     fun identityWithDtype() {
-        val identNdarray = mk.identity<Long>(3, DataType.LongDataType)
-        println(identNdarray)
+        val identNDArray = mk.identity<Long>(3, DataType.LongDataType)
+        println(identNDArray)
         /*
         [[1, 0, 0],
         [0, 1, 0],
@@ -791,9 +791,9 @@ class Ndarray {
     }
 
     @kotlin.test.Test
-    fun toNdarray() {
+    fun toNDArray() {
         val list = listOf(1, 2, 3, 4)
-        val ndarray = list.toNdarray()
+        val ndarray = list.toNDArray()
         println(ndarray) // [1, 2, 3, 4]
     }
 }

--- a/multik-default/src/main/kotlin/org/jetbrains/kotlinx/multik/default/DefaultLinAlg.kt
+++ b/multik-default/src/main/kotlin/org/jetbrains/kotlinx/multik/default/DefaultLinAlg.kt
@@ -10,14 +10,14 @@ import org.jetbrains.kotlinx.multik.jvm.JvmLinAlg
 import org.jetbrains.kotlinx.multik.ndarray.data.*
 
 public object DefaultLinAlg : LinAlg {
-    override fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): Ndarray<T, D2> {
+    override fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): NDArray<T, D2> {
         return JvmLinAlg.pow(mat, n)
     }
 
     override fun <T : Number> norm(mat: MultiArray<T, D2>, p: Int): Double = JvmLinAlg.norm(mat, p)
 
     //TODO()
-    override fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): Ndarray<T, D> {
+    override fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): NDArray<T, D> {
         return when (a.dtype) {
             DataType.FloatDataType -> NativeLinAlg.dot(a, b)
             DataType.DoubleDataType -> NativeLinAlg.dot(a, b)

--- a/multik-default/src/main/kotlin/org/jetbrains/kotlinx/multik/default/DefaultMath.kt
+++ b/multik-default/src/main/kotlin/org/jetbrains/kotlinx/multik/default/DefaultMath.kt
@@ -16,16 +16,16 @@ public object DefaultMath : Math {
         NativeMath.argMax(a)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> argMax(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O> =
+    override fun <T : Number, D : Dimension, O : Dimension> argMax(a: MultiArray<T, D>, axis: Int): NDArray<Int, O> =
         JvmMath.argMax(a, axis)
 
-    override fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1> = argMax(a, axis)
+    override fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1> = argMax(a, axis)
 
-    override fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2> = argMax(a, axis)
+    override fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2> = argMax(a, axis)
 
-    override fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3> = argMax(a, axis)
+    override fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3> = argMax(a, axis)
 
-    override fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4> = argMax(a, axis)
+    override fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4> = argMax(a, axis)
 
     override fun <T : Number, D : Dimension> argMin(a: MultiArray<T, D>): Int = if (a.size <= 100) {
         JvmMath.argMin(a)
@@ -33,24 +33,24 @@ public object DefaultMath : Math {
         NativeMath.argMin(a)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> argMin(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O> =
+    override fun <T : Number, D : Dimension, O : Dimension> argMin(a: MultiArray<T, D>, axis: Int): NDArray<Int, O> =
         JvmMath.argMin(a, axis)
 
-    override fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1> = argMin(a, axis)
+    override fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1> = argMin(a, axis)
 
-    override fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2> = argMin(a, axis)
+    override fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2> = argMin(a, axis)
 
-    override fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3> = argMin(a, axis)
+    override fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3> = argMin(a, axis)
 
-    override fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4> = argMin(a, axis)
+    override fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4> = argMin(a, axis)
 
-    override fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): Ndarray<Double, D> = NativeMath.exp(a)
+    override fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): NDArray<Double, D> = NativeMath.exp(a)
 
-    override fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): Ndarray<Double, D> = NativeMath.log(a)
+    override fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): NDArray<Double, D> = NativeMath.log(a)
 
-    override fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): Ndarray<Double, D> = NativeMath.sin(a)
+    override fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): NDArray<Double, D> = NativeMath.sin(a)
 
-    override fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): Ndarray<Double, D> = NativeMath.cos(a)
+    override fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): NDArray<Double, D> = NativeMath.cos(a)
 
     override fun <T : Number, D : Dimension> max(a: MultiArray<T, D>): T = if (a.size <= 100) {
         JvmMath.max(a)
@@ -58,16 +58,16 @@ public object DefaultMath : Math {
         NativeMath.max(a)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> max(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> =
+    override fun <T : Number, D : Dimension, O : Dimension> max(a: MultiArray<T, D>, axis: Int): NDArray<T, O> =
         JvmMath.max(a, axis)
 
-    override fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> = max(a, axis)
+    override fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> = max(a, axis)
 
-    override fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> = max(a, axis)
+    override fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> = max(a, axis)
 
-    override fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> = max(a, axis)
+    override fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> = max(a, axis)
 
-    override fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> = max(a, axis)
+    override fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> = max(a, axis)
 
     override fun <T : Number, D : Dimension> min(a: MultiArray<T, D>): T = if (a.size <= 100) {
         JvmMath.min(a)
@@ -75,16 +75,16 @@ public object DefaultMath : Math {
         NativeMath.min(a)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> min(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> =
+    override fun <T : Number, D : Dimension, O : Dimension> min(a: MultiArray<T, D>, axis: Int): NDArray<T, O> =
         JvmMath.min(a, axis)
 
-    override fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> = min(a, axis)
+    override fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> = min(a, axis)
 
-    override fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> = min(a, axis)
+    override fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> = min(a, axis)
 
-    override fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> = min(a, axis)
+    override fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> = min(a, axis)
 
-    override fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> = min(a, axis)
+    override fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> = min(a, axis)
 
     override fun <T : Number, D : Dimension> sum(a: MultiArray<T, D>): T = if (a.size <= 100) {
         JvmMath.sum(a)
@@ -92,20 +92,20 @@ public object DefaultMath : Math {
         NativeMath.sum(a)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> sum(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> =
+    override fun <T : Number, D : Dimension, O : Dimension> sum(a: MultiArray<T, D>, axis: Int): NDArray<T, O> =
         JvmMath.sum(a, axis)
 
-    override fun <T : Number> sumD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> = sum(a, axis)
+    override fun <T : Number> sumD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> = sum(a, axis)
 
-    override fun <T : Number> sumD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> = sum(a, axis)
+    override fun <T : Number> sumD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> = sum(a, axis)
 
-    override fun <T : Number> sumD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> = sum(a, axis)
+    override fun <T : Number> sumD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> = sum(a, axis)
 
-    override fun <T : Number> sumDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> = sum(a, axis)
+    override fun <T : Number> sumDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> = sum(a, axis)
 
     override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>): D1Array<T> = NativeMath.cumSum(a)
 
-    override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): Ndarray<T, D> =
+    override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): NDArray<T, D> =
         JvmMath.cumSum(a, axis)
 
 }

--- a/multik-default/src/main/kotlin/org/jetbrains/kotlinx/multik/default/DefaultStatistics.kt
+++ b/multik-default/src/main/kotlin/org/jetbrains/kotlinx/multik/default/DefaultStatistics.kt
@@ -16,15 +16,15 @@ public object DefaultStatistics : Statistics {
 
     override fun <T : Number, D : Dimension> mean(a: MultiArray<T, D>): Double = JvmStatistics.mean(a)
 
-    override fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): Ndarray<Double, O> =
+    override fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): NDArray<Double, O> =
         JvmStatistics.mean(a, axis)
 
-    override fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Double, D1> = mean(a, axis)
+    override fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): NDArray<Double, D1> = mean(a, axis)
 
-    override fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Double, D2> = mean(a, axis)
+    override fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): NDArray<Double, D2> = mean(a, axis)
 
-    override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Double, D3> = mean(a, axis)
+    override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Double, D4> = mean(a, axis)
+    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
 
 }

--- a/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmLinAlg.kt
+++ b/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmLinAlg.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlinx.multik.ndarray.operations.times
 import kotlin.math.pow
 
 public object JvmLinAlg : LinAlg {
-    override fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): Ndarray<T, D2> {
+    override fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): NDArray<T, D2> {
         if (n == 0) return mk.identity<T>(mat.shape[0], mat.dtype)
 
         return if (n % 2 == 0) {
@@ -32,16 +32,16 @@ public object JvmLinAlg : LinAlg {
         return n.pow(1 / p.toDouble())
     }
 
-    override fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): Ndarray<T, D> {
+    override fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): NDArray<T, D> {
         require(a.shape[1] == b.shape[0]) { "Shapes mismatch: shapes " +
                 "${a.shape.joinToString(prefix = "(", postfix = ")")} and " +
                 "${b.shape.joinToString(prefix = "(", postfix = ")")} not aligned: " +
                 "${a.shape[1]} (dim 1) != ${b.shape[0]} (dim 0)"}
 
         return if (b.dim.d == 2) {
-            dotMatrix(a, b as D2Array<T>) as Ndarray<T, D>
+            dotMatrix(a, b as D2Array<T>) as NDArray<T, D>
         } else {
-            dotVector(a, b as D1Array<T>) as Ndarray<T, D>
+            dotVector(a, b as D1Array<T>) as NDArray<T, D>
         }
     }
 

--- a/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmMath.kt
+++ b/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmMath.kt
@@ -269,7 +269,7 @@ public object JvmMath : Math {
 
     override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): Ndarray<T, D> {
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
-        val ret: Ndarray<T, D> = (a as Ndarray<T, D>).deepCope()
+        val ret: Ndarray<T, D> = (a as Ndarray<T, D>).deepCopy()
         val indexMap: MutableMap<Int, Indexing> = mutableMapOf()
         for (i in a.shape.indices) {
             if (i == axis) continue

--- a/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmMath.kt
+++ b/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmMath.kt
@@ -27,8 +27,8 @@ public object JvmMath : Math {
         return arg
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> argMax(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O> {
-        require(a.dim.d > 1) { "Ndarray of dimension one, use the `argMax` function without axis." }
+    override fun <T : Number, D : Dimension, O : Dimension> argMax(a: MultiArray<T, D>, axis: Int): NDArray<Int, O> {
+        require(a.dim.d > 1) { "NDArray of dimension one, use the `argMax` function without axis." }
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
         val newShape = a.shape.remove(axis)
         val min = JvmMath.min(a)
@@ -52,16 +52,16 @@ public object JvmMath : Math {
                 count++
             }
         }
-        return Ndarray<Int, O>(argMaxData, 0, newShape, dtype = DataType.IntDataType, dim = dimensionOf(newShape.size))
+        return NDArray<Int, O>(argMaxData, 0, newShape, dtype = DataType.IntDataType, dim = dimensionOf(newShape.size))
     }
 
-    override fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1> = argMax(a, axis)
+    override fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1> = argMax(a, axis)
 
-    override fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2> = argMax(a, axis)
+    override fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2> = argMax(a, axis)
 
-    override fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3> = argMax(a, axis)
+    override fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3> = argMax(a, axis)
 
-    override fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4> = argMax(a, axis)
+    override fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4> = argMax(a, axis)
 
     override fun <T : Number, D : Dimension> argMin(a: MultiArray<T, D>): Int {
         var arg = 0
@@ -77,8 +77,8 @@ public object JvmMath : Math {
         return arg
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> argMin(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O> {
-        require(a.dim.d > 1) { "Ndarray of dimension one, use the `argMin` function without axis." }
+    override fun <T : Number, D : Dimension, O : Dimension> argMin(a: MultiArray<T, D>, axis: Int): NDArray<Int, O> {
+        require(a.dim.d > 1) { "NDArray of dimension one, use the `argMin` function without axis." }
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
         val newShape = a.shape.remove(axis)
         val max = JvmMath.max(a)
@@ -102,30 +102,30 @@ public object JvmMath : Math {
                 count++
             }
         }
-        return Ndarray<Int, O>(argMinData, 0, newShape, dtype = DataType.IntDataType, dim = dimensionOf(newShape.size))
+        return NDArray<Int, O>(argMinData, 0, newShape, dtype = DataType.IntDataType, dim = dimensionOf(newShape.size))
     }
 
-    override fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1> = argMin(a, axis)
+    override fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1> = argMin(a, axis)
 
-    override fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2> = argMin(a, axis)
+    override fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2> = argMin(a, axis)
 
-    override fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3> = argMin(a, axis)
+    override fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3> = argMin(a, axis)
 
-    override fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4> = argMin(a, axis)
+    override fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4> = argMin(a, axis)
 
-    override fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a) { kotlin.math.exp(it) }
     }
 
-    override fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a) { ln(it) }
     }
 
-    override fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a) { kotlin.math.sin(it) }
     }
 
-    override fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a) { kotlin.math.cos(it) }
     }
 
@@ -135,8 +135,8 @@ public object JvmMath : Math {
         return max
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> max(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> {
-        require(a.dim.d > 1) { "Ndarray of dimension one, use the `max` function without axis." }
+    override fun <T : Number, D : Dimension, O : Dimension> max(a: MultiArray<T, D>, axis: Int): NDArray<T, O> {
+        require(a.dim.d > 1) { "NDArray of dimension one, use the `max` function without axis." }
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
         val newShape = a.shape.remove(axis)
         val min = JvmMath.min(a)
@@ -158,16 +158,16 @@ public object JvmMath : Math {
                 count++
             }
         }
-        return Ndarray<T, O>(maxData, 0, newShape, dtype = a.dtype, dim = dimensionOf(newShape.size))
+        return NDArray<T, O>(maxData, 0, newShape, dtype = a.dtype, dim = dimensionOf(newShape.size))
     }
 
-    override fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> = max(a, axis)
+    override fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> = max(a, axis)
 
-    override fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> = max(a, axis)
+    override fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> = max(a, axis)
 
-    override fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> = max(a, axis)
+    override fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> = max(a, axis)
 
-    override fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> = max(a, axis)
+    override fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> = max(a, axis)
 
     override fun <T : Number, D : Dimension> min(a: MultiArray<T, D>): T {
         var min = a.first()
@@ -175,8 +175,8 @@ public object JvmMath : Math {
         return min
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> min(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> {
-        require(a.dim.d > 1) { "Ndarray of dimension one, use the `min` function without axis." }
+    override fun <T : Number, D : Dimension, O : Dimension> min(a: MultiArray<T, D>, axis: Int): NDArray<T, O> {
+        require(a.dim.d > 1) { "NDArray of dimension one, use the `min` function without axis." }
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
         val newShape = a.shape.remove(axis)
         val max = JvmMath.max(a)
@@ -198,16 +198,16 @@ public object JvmMath : Math {
                 count++
             }
         }
-        return Ndarray<T, O>(minData, 0, newShape, dtype = a.dtype, dim = dimensionOf(newShape.size))
+        return NDArray<T, O>(minData, 0, newShape, dtype = a.dtype, dim = dimensionOf(newShape.size))
     }
 
-    override fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> = min(a, axis)
+    override fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> = min(a, axis)
 
-    override fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> = min(a, axis)
+    override fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> = min(a, axis)
 
-    override fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> = min(a, axis)
+    override fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> = min(a, axis)
 
-    override fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> = min(a, axis)
+    override fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> = min(a, axis)
 
     override fun <T : Number, D : Dimension> sum(a: MultiArray<T, D>): T {
         var accum = 0.0
@@ -221,11 +221,11 @@ public object JvmMath : Math {
         return accum.toPrimitiveType(a.dtype)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> sum(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> {
-        require(a.dim.d > 1) { "Ndarray of dimension one, use the `sum` function without axis." }
+    override fun <T : Number, D : Dimension, O : Dimension> sum(a: MultiArray<T, D>, axis: Int): NDArray<T, O> {
+        require(a.dim.d > 1) { "NDArray of dimension one, use the `sum` function without axis." }
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
         val newShape = a.shape.remove(axis)
-        val ret: Ndarray<T, O> = mk.empty(newShape, a.dtype)
+        val ret: NDArray<T, O> = mk.empty(newShape, a.dtype)
         val indexMap: MutableMap<Int, Indexing> = mutableMapOf()
         for (i in a.shape.indices) {
             if (i == axis) continue
@@ -239,13 +239,13 @@ public object JvmMath : Math {
     }
 
     // todo: without create view
-    override fun <T : Number> sumD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> = JvmMath.sum(a, axis)
+    override fun <T : Number> sumD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> = JvmMath.sum(a, axis)
 
-    override fun <T : Number> sumD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> = JvmMath.sum(a, axis)
+    override fun <T : Number> sumD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> = JvmMath.sum(a, axis)
 
-    override fun <T : Number> sumD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> = JvmMath.sum(a, axis)
+    override fun <T : Number> sumD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> = JvmMath.sum(a, axis)
 
-    override fun <T : Number> sumDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> = JvmMath.sum(a, axis)
+    override fun <T : Number> sumDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> = JvmMath.sum(a, axis)
 
     override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>): D1Array<T> {
         val ret = D1Array<Double>(
@@ -267,9 +267,9 @@ public object JvmMath : Math {
         return ret.asType<T>(a.dtype)
     }
 
-    override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): Ndarray<T, D> {
+    override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): NDArray<T, D> {
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
-        val ret: Ndarray<T, D> = (a as Ndarray<T, D>).deepCopy()
+        val ret: NDArray<T, D> = (a as NDArray<T, D>).deepCopy()
         val indexMap: MutableMap<Int, Indexing> = mutableMapOf()
         for (i in a.shape.indices) {
             if (i == axis) continue
@@ -286,7 +286,7 @@ public object JvmMath : Math {
 
     private fun <T : Number, D : Dimension> mathOperation(
         a: MultiArray<T, D>, function: (Double) -> Double
-    ): Ndarray<Double, D> {
+    ): NDArray<Double, D> {
         val iter = a.iterator()
         val data = initMemoryView<Double>(a.size, DataType.DoubleDataType) {
             if (iter.hasNext())
@@ -294,7 +294,7 @@ public object JvmMath : Math {
             else
                 0.0
         }
-        return Ndarray<Double, D>(data, 0, a.shape, dtype = DataType.DoubleDataType, dim = a.dim)
+        return NDArray<Double, D>(data, 0, a.shape, dtype = DataType.DoubleDataType, dim = a.dim)
     }
 }
 

--- a/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmStatistics.kt
+++ b/multik-jvm/src/main/kotlin/org/jetbrains/kotlinx/multik/jvm/JvmStatistics.kt
@@ -40,8 +40,8 @@ public object JvmStatistics : Statistics {
         return ret.toDouble() / a.size
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): Ndarray<Double, O> {
-        require(a.dim.d > 1) { "Ndarray of dimension one, use the `mean` function without axis." }
+    override fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): NDArray<Double, O> {
+        require(a.dim.d > 1) { "NDArray of dimension one, use the `mean` function without axis." }
         require(axis in 0 until a.dim.d) { "axis $axis is out of bounds for this ndarray of dimension ${a.dim.d}." }
         val newShape = a.shape.remove(axis)
         val retData = initMemoryView<Double>(newShape.fold(1, Int::times), DataType.DoubleDataType)
@@ -59,16 +59,16 @@ public object JvmStatistics : Statistics {
             }
         }
 
-        return Ndarray<Double, O>(
+        return NDArray<Double, O>(
             retData, 0, newShape, dtype = DataType.DoubleDataType, dim = dimensionOf(newShape.size)
         ) / a.shape[axis].toDouble()
     }
 
-    override fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Double, D1> = mean(a, axis)
+    override fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): NDArray<Double, D1> = mean(a, axis)
 
-    override fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Double, D2> = mean(a, axis)
+    override fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): NDArray<Double, D2> = mean(a, axis)
 
-    override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Double, D3> = mean(a, axis)
+    override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Double, D4> = mean(a, axis)
+    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
 }

--- a/multik-native/src/main/kotlin/org/jetbrains/kotlinx/multik/jni/JniLinAlg.kt
+++ b/multik-native/src/main/kotlin/org/jetbrains/kotlinx/multik/jni/JniLinAlg.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlinx.multik.api.LinAlg
 import org.jetbrains.kotlinx.multik.ndarray.data.*
 
 public object NativeLinAlg : LinAlg {
-    override fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): Ndarray<T, D2> {
+    override fun <T : Number> pow(mat: MultiArray<T, D2>, n: Int): NDArray<T, D2> {
         TODO("Not yet implemented")
     }
 
@@ -17,7 +17,7 @@ public object NativeLinAlg : LinAlg {
     }
 
     //TODO (Double and Number type)
-    override fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): Ndarray<T, D> {
+    override fun <T : Number, D : Dim2> dot(a: MultiArray<T, D2>, b: MultiArray<T, D>): NDArray<T, D> {
         require(a.shape[1] == b.shape[0]) {
             "Shapes mismatch: shapes " +
                     "${a.shape.joinToString(prefix = "(", postfix = ")")} and " +
@@ -39,7 +39,7 @@ public object NativeLinAlg : LinAlg {
                     D2Array<Double>(MemoryViewDoubleArray(c), 0, shape, dtype = DataType.DoubleDataType, dim = D2)
                 }
                 else -> throw UnsupportedOperationException()
-            } as Ndarray<T, D>
+            } as NDArray<T, D>
         } else {
             val shape = intArrayOf(a.shape[0])
             when (a.dtype) {
@@ -54,7 +54,7 @@ public object NativeLinAlg : LinAlg {
                     D1Array<Double>(MemoryViewDoubleArray(c), 0, shape, dtype = a.dtype, dim = D1)
                 }
                 else -> throw UnsupportedOperationException()
-            } as Ndarray<T, D>
+            } as NDArray<T, D>
         }
     }
 

--- a/multik-native/src/main/kotlin/org/jetbrains/kotlinx/multik/jni/JniMath.kt
+++ b/multik-native/src/main/kotlin/org/jetbrains/kotlinx/multik/jni/JniMath.kt
@@ -12,23 +12,23 @@ public object NativeMath : Math {
         return JniMath.argMax(a.data.data, a.offset, a.size, a.shape, a.strides, a.dtype.nativeCode)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> argMax(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O> {
+    override fun <T : Number, D : Dimension, O : Dimension> argMax(a: MultiArray<T, D>, axis: Int): NDArray<Int, O> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1> {
+    override fun <T : Number> argMaxD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2> {
+    override fun <T : Number> argMaxD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3> {
+    override fun <T : Number> argMaxD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4> {
+    override fun <T : Number> argMaxDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4> {
         TODO("Not yet implemented")
     }
 
@@ -36,39 +36,39 @@ public object NativeMath : Math {
         return JniMath.argMin(a.data.data, a.offset, a.size, a.shape, a.strides, a.dtype.nativeCode)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> argMin(a: MultiArray<T, D>, axis: Int): Ndarray<Int, O> {
+    override fun <T : Number, D : Dimension, O : Dimension> argMin(a: MultiArray<T, D>, axis: Int): NDArray<Int, O> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Int, D1> {
+    override fun <T : Number> argMinD2(a: MultiArray<T, D2>, axis: Int): NDArray<Int, D1> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Int, D2> {
+    override fun <T : Number> argMinD3(a: MultiArray<T, D3>, axis: Int): NDArray<Int, D2> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Int, D3> {
+    override fun <T : Number> argMinD4(a: MultiArray<T, D4>, axis: Int): NDArray<Int, D3> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Int, D4> {
+    override fun <T : Number> argMinDN(a: MultiArray<T, DN>, axis: Int): NDArray<Int, D4> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> exp(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a, JniMath::exp)
     }
 
-    override fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> log(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a, JniMath::log)
     }
 
-    override fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> sin(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a, JniMath::sin)
     }
 
-    override fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): Ndarray<Double, D> {
+    override fun <T : Number, D : Dimension> cos(a: MultiArray<T, D>): NDArray<Double, D> {
         return mathOperation(a, JniMath::cos)
     }
 
@@ -76,23 +76,23 @@ public object NativeMath : Math {
         return JniMath.max(a.data.data, a.offset, a.size, a.shape, a.strides, a.dtype.nativeCode)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> max(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> {
+    override fun <T : Number, D : Dimension, O : Dimension> max(a: MultiArray<T, D>, axis: Int): NDArray<T, O> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> {
+    override fun <T : Number> maxD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> {
+    override fun <T : Number> maxD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> {
+    override fun <T : Number> maxD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> {
+    override fun <T : Number> maxDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> {
         TODO("Not yet implemented")
     }
 
@@ -100,23 +100,23 @@ public object NativeMath : Math {
         return JniMath.min(a.data.data, a.offset, a.size, a.shape, a.strides, a.dtype.nativeCode)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> min(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> {
+    override fun <T : Number, D : Dimension, O : Dimension> min(a: MultiArray<T, D>, axis: Int): NDArray<T, O> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> {
+    override fun <T : Number> minD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> {
+    override fun <T : Number> minD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> {
+    override fun <T : Number> minD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> {
+    override fun <T : Number> minDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> {
         TODO("Not yet implemented")
     }
 
@@ -124,23 +124,23 @@ public object NativeMath : Math {
         return JniMath.sum(a.data.data, a.offset, a.size, a.shape, a.strides, a.dtype.nativeCode)
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> sum(a: MultiArray<T, D>, axis: Int): Ndarray<T, O> {
+    override fun <T : Number, D : Dimension, O : Dimension> sum(a: MultiArray<T, D>, axis: Int): NDArray<T, O> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> sumD2(a: MultiArray<T, D2>, axis: Int): Ndarray<T, D1> {
+    override fun <T : Number> sumD2(a: MultiArray<T, D2>, axis: Int): NDArray<T, D1> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> sumD3(a: MultiArray<T, D3>, axis: Int): Ndarray<T, D2> {
+    override fun <T : Number> sumD3(a: MultiArray<T, D3>, axis: Int): NDArray<T, D2> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> sumD4(a: MultiArray<T, D4>, axis: Int): Ndarray<T, D3> {
+    override fun <T : Number> sumD4(a: MultiArray<T, D4>, axis: Int): NDArray<T, D3> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> sumDN(a: MultiArray<T, DN>, axis: Int): Ndarray<T, D4> {
+    override fun <T : Number> sumDN(a: MultiArray<T, DN>, axis: Int): NDArray<T, D4> {
         TODO("Not yet implemented")
     }
 
@@ -150,17 +150,17 @@ public object NativeMath : Math {
         return ret
     }
 
-    override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): Ndarray<T, D> {
+    override fun <T : Number, D : Dimension> cumSum(a: MultiArray<T, D>, axis: Int): NDArray<T, D> {
         TODO("Not yet implemented")
     }
 
     private fun <T : Number, D : Dimension> mathOperation(
         a: MultiArray<T, D>,
         function: (arr: Any, offset: Int, size: Int, shape: IntArray, strides: IntArray, out: DoubleArray, dtype: Int) -> Boolean
-    ): Ndarray<Double, D> {
+    ): NDArray<Double, D> {
         val data = MemoryViewDoubleArray(DoubleArray(a.size))
         function(a.data.data, a.offset, a.size, a.shape, a.strides, data.data, a.dtype.nativeCode)
-        return Ndarray<Double, D>(data, 0, a.shape, dtype = DataType.DoubleDataType, dim = a.dim)
+        return NDArray<Double, D>(data, 0, a.shape, dtype = DataType.DoubleDataType, dim = a.dim)
     }
 
 }

--- a/multik-native/src/main/kotlin/org/jetbrains/kotlinx/multik/jni/JniStatistics.kt
+++ b/multik-native/src/main/kotlin/org/jetbrains/kotlinx/multik/jni/JniStatistics.kt
@@ -20,23 +20,23 @@ public object NativeStatistics : Statistics {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): Ndarray<Double, O> {
+    override fun <T : Number, D : Dimension, O : Dimension> mean(a: MultiArray<T, D>, axis: Int): NDArray<Double, O> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): Ndarray<Double, D1> {
+    override fun <T : Number> meanD2(a: MultiArray<T, D2>, axis: Int): NDArray<Double, D1> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): Ndarray<Double, D2> {
+    override fun <T : Number> meanD3(a: MultiArray<T, D3>, axis: Int): NDArray<Double, D2> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): Ndarray<Double, D3> {
+    override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): Ndarray<Double, D4> {
+    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
This PR renames `deepCope()` to `deepCopy()`.

It also uses CamelCase for `NDArray`:

- Renames `toNdarray()` to `toNDArray()`.
- Renames `asDNArray()` to `asNDArray()`.
- Renames method names containing `Ndarray` to `NDArray`
- Renames class names containing `Ndarray` to `NDArray`
- Fixes indefinite article in comments (`a ndarray` to `an ndarray`)

The `ndarray`/`dnarray` methods are a bit confusing, but I do not see a way to unify their names without clashing type signatures. One solution is to rename everything to `dnarray`/`DNArray` to match the `D1..D4Array` convention, but that might surprise NumPy users.