### PR TITLE
adding re and im properties for arrays of complex numbers

### DIFF
--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/_NDArray.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/_NDArray.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlinx.multik.ndarray.complex
 
 import org.jetbrains.kotlinx.multik.ndarray.data.Dimension
+import org.jetbrains.kotlinx.multik.ndarray.data.MultiArray
 import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
 import org.jetbrains.kotlinx.multik.ndarray.operations.map
 
@@ -12,8 +13,8 @@ import org.jetbrains.kotlinx.multik.ndarray.operations.map
  * @return [NDArray] of real portion of [ComplexFloat]
  */
 @get:JvmName("reFloat")
-public val <D : Dimension> NDArray<ComplexFloat, D>.re: NDArray<Float, D>
-    get() { return this.map { it.re } }
+public val <D : Dimension> MultiArray<ComplexFloat, D>.re: NDArray<Float, D>
+    get() = this.map { it.re }
 
 /**
  * Transforms this [NDArray] of [ComplexDouble] to an [NDArray] of the real part of complex numbers.
@@ -23,8 +24,8 @@ public val <D : Dimension> NDArray<ComplexFloat, D>.re: NDArray<Float, D>
  * @return [NDArray] of real portion of [ComplexDouble]
  */
 @get:JvmName("reDouble")
-public val <D : Dimension> NDArray<ComplexDouble, D>.re: NDArray<Double, D>
-    get() { return this.map { it.re } }
+public val <D : Dimension> MultiArray<ComplexDouble, D>.re: NDArray<Double, D>
+    get() = this.map { it.re }
 
 /**
  * Transforms this [NDArray] of [ComplexFloat] to an [NDArray] of the imaginary part of complex numbers.
@@ -34,8 +35,8 @@ public val <D : Dimension> NDArray<ComplexDouble, D>.re: NDArray<Double, D>
  * @return [NDArray] of imaginary portion of [ComplexFloat]
  */
 @get:JvmName("imFloat")
-public val <D : Dimension> NDArray<ComplexFloat, D>.im: NDArray<Float, D>
-    get() { return this.map { it.im } }
+public val <D : Dimension> MultiArray<ComplexFloat, D>.im: NDArray<Float, D>
+    get() = this.map { it.im }
 
 /**
  * Transforms this [NDArray] of [ComplexDouble] to an [NDArray] of the imaginary part of complex numbers.
@@ -45,5 +46,5 @@ public val <D : Dimension> NDArray<ComplexFloat, D>.im: NDArray<Float, D>
  * @return [NDArray] of imaginary portion of [ComplexDouble]
  */
 @get:JvmName("imDouble")
-public val <D : Dimension> NDArray<ComplexDouble, D>.im: NDArray<Double, D>
-    get() { return this.map { it.im } }
+public val <D : Dimension> MultiArray<ComplexDouble, D>.im: NDArray<Double, D>
+    get() = this.map { it.im }

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/ComplexMultiArrayTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/ComplexMultiArrayTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class ComplexNDArrayTest {
+class ComplexMultiArrayTest {
 
     @Test
     fun `re and im properties returns real and imaginary portion of float complex number array`() {


### PR DESCRIPTION
- issue: https://github.com/Kotlin/multik/issues/53
- needed to add `@get:JvmName` to properties, because the function signatures clash on JVM (without annotation, both Double and Float generate a method called `re_get`)
- tested with `./gradlew :multik-api:clean :multik-api:assemble :multik-api:test :multik-api:dokkaHtml`
