### PR TITLE
added easy complex creation.

### DIFF
--- a/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/_Complex.kt
+++ b/multik-api/src/main/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/_Complex.kt
@@ -61,3 +61,16 @@ public operator fun Int.div(other: ComplexDouble): ComplexDouble = ComplexDouble
 public operator fun Long.div(other: ComplexDouble): ComplexDouble = ComplexDouble(this.toDouble(), 0.0) / other
 public operator fun Float.div(other: ComplexDouble): ComplexDouble = ComplexDouble(this.toDouble(), 0.0) / other
 public operator fun Double.div(other: ComplexDouble): ComplexDouble = ComplexDouble(this, 0.0) / other
+
+public val Byte.i: ComplexDouble
+    get() = ComplexDouble(0, this.toDouble())
+public val Short.i: ComplexDouble
+    get() = ComplexDouble(0, this.toDouble())
+public val Int.i: ComplexDouble
+    get() = ComplexDouble(0, this.toDouble())
+public val Long.i: ComplexDouble
+    get() = ComplexDouble(0, this.toDouble())
+public val Float.i: ComplexFloat
+    get() = ComplexFloat(0, this)
+public val Double.i: ComplexDouble
+    get() = ComplexDouble(0, this)

--- a/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/CreateComplexTest.kt
+++ b/multik-api/src/test/kotlin/org/jetbrains/kotlinx/multik/ndarray/complex/CreateComplexTest.kt
@@ -1,0 +1,20 @@
+package org.jetbrains.kotlinx.multik.ndarray.complex
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CreateComplexTest {
+
+    @Test
+    fun `test easy complex creation`() {
+        assertEquals(Complex.i(0x01.toDouble()), 0x01.i)
+        assertEquals(Complex.i(1.toShort().toDouble()), 1.toShort().i)
+        assertEquals(Complex.i(1.toDouble()), 1.i)
+        assertEquals(Complex.i(1L.toDouble()), 1L.i)
+        assertEquals(Complex.i(1f), 1f.i)
+        assertEquals(Complex.i(1.0), 1.0.i)
+
+        assertEquals(ComplexFloat(1, 1), 1 + 1f.i)
+        assertEquals(ComplexDouble(1, 1), 1 + 1.i)
+    }
+}


### PR DESCRIPTION
resolves https://github.com/Kotlin/multik/issues/56 

I made `1.i` create a ComplexDouble as opposed to a ComplexFloat which leads to this unexpected behaviour.
```kt
ComplexDouble(1, 1) == 1f + 1.i
```
My reasoning is that Double seems to be Koltin's default (`1.0 is Double`, `(1.0 as Number) !is Float`).

I'm not sure of a super elegant way to resolve this, I could create some form of `CoorcingComplex` that is created for Byte, Int, Short and Long `.i` that coerces to whatever other Complex/Number it operates with, but this may just be too much code for such a simple feature. If someone with more experience thinks a class like that is worthwhile, I'd be happy to implement it. (Or if there's a straight-up better solution!)