### PR TITLE
Add `norm` API for vectors

### DIFF
--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/linalg/norm.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/linalg/norm.kt
@@ -4,15 +4,33 @@
 
 package org.jetbrains.kotlinx.multik.api.linalg
 
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.zeros
+import org.jetbrains.kotlinx.multik.ndarray.data.D1
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
 import org.jetbrains.kotlinx.multik.ndarray.data.MultiArray
+import org.jetbrains.kotlinx.multik.ndarray.operations.stack
 import kotlin.jvm.JvmName
+
+/**
+ * Returns norm of float vector
+ */
+@JvmName("normFV")
+public fun LinAlg.norm(mat: MultiArray<Float, D1>, norm: Norm = Norm.Fro): Float =
+    this.linAlgEx.normF(mk.stack(mat, mk.zeros(mat.size)), norm)
 
 /**
  * Returns norm of float matrix
  */
 @JvmName("normF")
 public fun LinAlg.norm(mat: MultiArray<Float, D2>, norm: Norm = Norm.Fro): Float = this.linAlgEx.normF(mat, norm)
+
+/**
+ * Returns norm of double vector
+ */
+@JvmName("normDV")
+public fun LinAlg.norm(mat: MultiArray<Double, D1>, norm: Norm = Norm.Fro): Double =
+    this.linAlgEx.norm(mk.stack(mat, mk.zeros(mat.size)), norm)
 
 /**
  * Returns norm of double matrix

--- a/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/linAlg/KELinAlgTest.kt
+++ b/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/linAlg/KELinAlgTest.kt
@@ -5,26 +5,49 @@
 package org.jetbrains.kotlinx.multik_kotlin.linAlg
 
 
-import org.jetbrains.kotlinx.multik.api.*
-import org.jetbrains.kotlinx.multik.api.linalg.Norm
-import org.jetbrains.kotlinx.multik.api.linalg.dot
-import org.jetbrains.kotlinx.multik.api.linalg.norm
-import org.jetbrains.kotlinx.multik.kotlin.linalg.*
-import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx.solve
-import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx.solveC
-import org.jetbrains.kotlinx.multik.ndarray.complex.Complex
-import org.jetbrains.kotlinx.multik.ndarray.complex.ComplexDouble
-import org.jetbrains.kotlinx.multik.ndarray.complex.ComplexFloat
-import org.jetbrains.kotlinx.multik.ndarray.complex.toComplexDouble
-import org.jetbrains.kotlinx.multik.ndarray.data.*
-import org.jetbrains.kotlinx.multik.ndarray.operations.map
-import org.jetbrains.kotlinx.multik.ndarray.operations.minus
-import org.jetbrains.kotlinx.multik.ndarray.operations.plus
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.jetbrains.kotlinx.multik.api.d1array
+import org.jetbrains.kotlinx.multik.api.d2array
+import org.jetbrains.kotlinx.multik.api.linalg.Norm
+import org.jetbrains.kotlinx.multik.api.linalg.dot
+import org.jetbrains.kotlinx.multik.api.linalg.norm
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.ndarray
+import org.jetbrains.kotlinx.multik.api.zeros
+import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlg
+import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx
+import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx.solve
+import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx.solveC
+import org.jetbrains.kotlinx.multik.kotlin.linalg.conjTranspose
+import org.jetbrains.kotlinx.multik.kotlin.linalg.dotMatrixComplex
+import org.jetbrains.kotlinx.multik.kotlin.linalg.gramShmidtComplexDouble
+import org.jetbrains.kotlinx.multik.kotlin.linalg.qrComplexDouble
+import org.jetbrains.kotlinx.multik.kotlin.linalg.schurDecomposition
+import org.jetbrains.kotlinx.multik.kotlin.linalg.upperHessenbergDouble
+import org.jetbrains.kotlinx.multik.ndarray.complex.Complex
+import org.jetbrains.kotlinx.multik.ndarray.complex.ComplexDouble
+import org.jetbrains.kotlinx.multik.ndarray.complex.ComplexFloat
+import org.jetbrains.kotlinx.multik.ndarray.complex.toComplexDouble
+import org.jetbrains.kotlinx.multik.ndarray.data.D1Array
+import org.jetbrains.kotlinx.multik.ndarray.data.D2
+import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
+import org.jetbrains.kotlinx.multik.ndarray.data.DataType
+import org.jetbrains.kotlinx.multik.ndarray.data.Dim2
+import org.jetbrains.kotlinx.multik.ndarray.data.MultiArray
+import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
+import org.jetbrains.kotlinx.multik.ndarray.data.get
+import org.jetbrains.kotlinx.multik.ndarray.data.set
+import org.jetbrains.kotlinx.multik.ndarray.operations.map
+import org.jetbrains.kotlinx.multik.ndarray.operations.minus
+import org.jetbrains.kotlinx.multik.ndarray.operations.plus
 
 class KELinAlgTest {
 
@@ -491,6 +514,16 @@ class KELinAlgTest {
             assertTrue("${trueEigavals[i]} =/= ${testedEigenvals[i]}") { (trueEigavals[i] - testedEigenvals[i]).abs() < precision}
         }
 
+    }
+
+    @Test
+    fun compute_norm_for_vector() {
+        val vector = mk.ndarray(mk[1.1, 0.0, 3.2, 2.3, 5.0])
+
+        assertEquals(6.460650122085238, mk.linalg.norm(vector, Norm.Fro))
+        assertEquals(11.600000000000001, mk.linalg.norm(vector, Norm.Inf))
+        assertEquals(5.0, mk.linalg.norm(vector, Norm.N1))
+        assertEquals(5.0, mk.linalg.norm(vector, Norm.Max))
     }
 }
 

--- a/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/linAlg/KELinAlgTest.kt
+++ b/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/linAlg/KELinAlgTest.kt
@@ -5,49 +5,26 @@
 package org.jetbrains.kotlinx.multik_kotlin.linAlg
 
 
-import kotlin.math.abs
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
-import org.jetbrains.kotlinx.multik.api.d1array
-import org.jetbrains.kotlinx.multik.api.d2array
+import org.jetbrains.kotlinx.multik.api.*
 import org.jetbrains.kotlinx.multik.api.linalg.Norm
 import org.jetbrains.kotlinx.multik.api.linalg.dot
 import org.jetbrains.kotlinx.multik.api.linalg.norm
-import org.jetbrains.kotlinx.multik.api.mk
-import org.jetbrains.kotlinx.multik.api.ndarray
-import org.jetbrains.kotlinx.multik.api.zeros
-import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlg
-import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx
+import org.jetbrains.kotlinx.multik.kotlin.linalg.*
 import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx.solve
 import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx.solveC
-import org.jetbrains.kotlinx.multik.kotlin.linalg.conjTranspose
-import org.jetbrains.kotlinx.multik.kotlin.linalg.dotMatrixComplex
-import org.jetbrains.kotlinx.multik.kotlin.linalg.gramShmidtComplexDouble
-import org.jetbrains.kotlinx.multik.kotlin.linalg.qrComplexDouble
-import org.jetbrains.kotlinx.multik.kotlin.linalg.schurDecomposition
-import org.jetbrains.kotlinx.multik.kotlin.linalg.upperHessenbergDouble
 import org.jetbrains.kotlinx.multik.ndarray.complex.Complex
 import org.jetbrains.kotlinx.multik.ndarray.complex.ComplexDouble
 import org.jetbrains.kotlinx.multik.ndarray.complex.ComplexFloat
 import org.jetbrains.kotlinx.multik.ndarray.complex.toComplexDouble
-import org.jetbrains.kotlinx.multik.ndarray.data.D1Array
-import org.jetbrains.kotlinx.multik.ndarray.data.D2
-import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
-import org.jetbrains.kotlinx.multik.ndarray.data.DataType
-import org.jetbrains.kotlinx.multik.ndarray.data.Dim2
-import org.jetbrains.kotlinx.multik.ndarray.data.MultiArray
-import org.jetbrains.kotlinx.multik.ndarray.data.NDArray
-import org.jetbrains.kotlinx.multik.ndarray.data.get
-import org.jetbrains.kotlinx.multik.ndarray.data.set
+import org.jetbrains.kotlinx.multik.ndarray.data.*
 import org.jetbrains.kotlinx.multik.ndarray.operations.map
 import org.jetbrains.kotlinx.multik.ndarray.operations.minus
 import org.jetbrains.kotlinx.multik.ndarray.operations.plus
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.random.Random
+import kotlin.test.*
 
 class KELinAlgTest {
 

--- a/multik-openblas/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/openblas/linalg/NativeLinAlgTest.kt
+++ b/multik-openblas/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/openblas/linalg/NativeLinAlgTest.kt
@@ -324,4 +324,14 @@ class NativeLinAlgTest {
         assertFloatingNumber(7.0, NativeLinAlg.norm(b, Norm.N1))
         assertFloatingNumber(4.0, NativeLinAlg.norm(b, Norm.Max))
     }
+
+    @Test
+    fun `compute norm for vector`() {
+        val vector = mk.ndarray(mk[1.1, 0.0, 3.2, 2.3, 5.0])
+
+        assertEquals(6.460650122085238, mk.linalg.norm(vector, Norm.Fro))
+        assertEquals(11.600000000000001, mk.linalg.norm(vector, Norm.Inf))
+        assertEquals(5.0, mk.linalg.norm(vector, Norm.N1))
+        assertEquals(5.0, mk.linalg.norm(vector, Norm.Max))
+    }
 }


### PR DESCRIPTION
## What
added `norm` APIs for vector type (i.e., `MultiArray<Float, D1>` and `MultiArray<Double, D1>`).
in this implementation, reusing existing `norm` methods by using origin vector (`mk.zeros(size)`).

## Why
currently, there are `norm` methods accepting only matrix (i.e., `MultiArray<Number, D2>`).
however, NumPy provides `norm` methods for vector.
sample: https://stackoverflow.com/a/43043160

i think it is better to provide the similar API for usability.

## Questions
- in this PR, i added new methods to `norm.kt`, but should i add them to `LinAlgEx.kt` file?
- where should i add tests?