### PR TITLE
diagonal matrix creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ val e = mk.identity<Double>(3) // create an identity array of shape (3, 3)
 [0.0, 1.0, 0.0],
 [0.0, 0.0, 1.0]]
 */
+
+val diag = mk.diagonal(2, 4, 8) // create a diagonal array
+/*
+[[2, 0, 0],
+[0, 4, 0],
+[0, 0, 8]]
+ */
 ```
 
 #### Array properties

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ val e = mk.identity<Double>(3) // create an identity array of shape (3, 3)
 [0.0, 0.0, 1.0]]
 */
 
-val diag = mk.diagonal(2, 4, 8) // create a diagonal array
+val diag = mk.diagonal(mk[2, 4, 8]) // create a diagonal array
 /*
 [[2, 0, 0],
 [0, 4, 0],

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/constructors.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/constructors.kt
@@ -210,9 +210,9 @@ public fun <T> Multik.identity(n: Int, dtype: DataType): D2Array<T> {
  * @return [D2Array].
  * @sample samples.NDArrayTest.diagonal
  */
-public inline fun <reified T : Any> Multik.diagonal(vararg elements: T): D2Array<T> {
+public inline fun <reified T : Any> Multik.diagonal(elements: List<T>): D2Array<T> {
     val dtype = DataType.ofKClass(T::class)
-    return diagonal(dtype = dtype, elements = elements)
+    return diagonal(elements = elements, dtype = dtype)
 }
 
 /**
@@ -225,7 +225,7 @@ public inline fun <reified T : Any> Multik.diagonal(vararg elements: T): D2Array
  * @return [D2Array]
  * @sample samples.NDArrayTest.diagonalWithDtype
  */
-public fun <T> Multik.diagonal(dtype: DataType, vararg elements: T): D2Array<T> {
+public fun <T> Multik.diagonal(elements: List<T>, dtype: DataType): D2Array<T> {
     val n = elements.size
     val shape = intArrayOf(n, n)
     val ret = D2Array(initMemoryView<T>(n * n, dtype), shape = shape, dim = D2)

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/constructors.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/constructors.kt
@@ -204,6 +204,38 @@ public fun <T> Multik.identity(n: Int, dtype: DataType): D2Array<T> {
 }
 
 /**
+ * Returns a diagonal array.
+ *
+ * @param elements the elements along the main diagonal.
+ * @return [D2Array].
+ * @sample samples.NDArrayTest.diagonal
+ */
+public inline fun <reified T : Any> Multik.diagonal(vararg elements: T): D2Array<T> {
+    val dtype = DataType.ofKClass(T::class)
+    return diagonal(dtype = dtype, elements = elements)
+}
+
+/**
+ * Returns a diagonal array.
+ *
+ * Note: Generic type of elements must match [dtype].
+ *
+ * @param dtype array type.
+ * @param elements the elements on the main diagonal.
+ * @return [D2Array]
+ * @sample samples.NDArrayTest.diagonalWithDtype
+ */
+public fun <T> Multik.diagonal(dtype: DataType, vararg elements: T): D2Array<T> {
+    val n = elements.size
+    val shape = intArrayOf(n, n)
+    val ret = D2Array(initMemoryView<T>(n * n, dtype), shape = shape, dim = D2)
+    for (i in 0 until n) {
+        ret[i, i] = elements[i]
+    }
+    return ret
+}
+
+/**
  * Creates the 1-dimension array from [arg] of Number type.
  *
  * Example:

--- a/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/creation/create2DArray.kt
+++ b/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/creation/create2DArray.kt
@@ -81,7 +81,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalByteMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { (it + 1).toByte() }.toTypedArray())
+        val a = mk.diagonal(List(n) { (it + 1).toByte() })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -250,7 +250,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalShortMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { (it + 1).toShort() }.toTypedArray())
+        val a = mk.diagonal(List(n) { (it + 1).toShort() })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -422,7 +422,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalIntMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { it + 1 }.toTypedArray())
+        val a = mk.diagonal(List(n) { it + 1 })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -593,7 +593,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalLongMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { it + 1L }.toTypedArray())
+        val a = mk.diagonal(List(n) { it + 1L })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -762,7 +762,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalFloatMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { it + 1f }.toTypedArray())
+        val a = mk.diagonal(List(n) { it + 1f })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -932,7 +932,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalDoubleMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { it + 1.0 }.toTypedArray())
+        val a = mk.diagonal(List(n) { it + 1.0 })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -1105,7 +1105,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalComplexFloatMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { ComplexFloat(it + 1f, it + 1f) }.toTypedArray())
+        val a = mk.diagonal(List(n) { ComplexFloat(it + 1f, it + 1f) })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {
@@ -1256,7 +1256,7 @@ class Create2DArrayTests {
     @Test
     fun createDiagonalComplexDoubleMatrix() {
         val n = 7
-        val a = mk.diagonal(*List(n) { ComplexDouble(it + 1.0, it + 1.0) }.toTypedArray())
+        val a = mk.diagonal(List(n) { ComplexDouble(it + 1.0, it + 1.0) })
 
         assertEquals(n * n, a.size)
         for (i in 0 until n) {

--- a/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/creation/create2DArray.kt
+++ b/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/creation/create2DArray.kt
@@ -73,6 +73,28 @@ class Create2DArrayTests {
     }
 
     /**
+     * Tests the function 'mk.diagonal<Byte>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalByteMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { (it + 1).toByte() }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals((i + 1).toByte(), a[i, j], "Expected element at [$i:$j] to be ${i + 1}")
+                else
+                    assertEquals(0, a[i, j], "Expected non-diagonal elements to be 0")
+            }
+        }
+    }
+
+    /**
      * Creates a two-dimensional array from a list of byte lists
      * and checks if the array's list representation matches the input list.
      */
@@ -213,6 +235,28 @@ class Create2DArrayTests {
             for (j in 0 until n) {
                 if (i == j)
                     assertEquals(1, a[i, j], "Expected diagonal elements to be 1")
+                else
+                    assertEquals(0, a[i, j], "Expected non-diagonal elements to be 0")
+            }
+        }
+    }
+
+    /**
+     * Tests the function 'mk.diagonal<Short>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalShortMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { (it + 1).toShort() }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals((i + 1).toShort(), a[i, j], "Expected element at [$i:$j] to be ${i + 1}")
                 else
                     assertEquals(0, a[i, j], "Expected non-diagonal elements to be 0")
             }
@@ -369,6 +413,28 @@ class Create2DArrayTests {
         }
     }
 
+    /**
+     * Tests the function 'mk.diagonal<Int>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalIntMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { it + 1 }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals(i + 1, a[i, j], "Expected element at [$i:$j] to be ${i + 1}")
+                else
+                    assertEquals(0, a[i, j], "Expected non-diagonal elements to be 0")
+            }
+        }
+    }
+
 
     /**
      * Creates a two-dimensional array from a list of integer lists
@@ -512,6 +578,28 @@ class Create2DArrayTests {
             for (j in 0 until n) {
                 if (i == j)
                     assertEquals(1L, a[i, j], "Expected diagonal elements to be 1")
+                else
+                    assertEquals(0L, a[i, j], "Expected non-diagonal elements to be 0")
+            }
+        }
+    }
+
+    /**
+     * Tests the function 'mk.diagonal<Long>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalLongMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { it + 1L }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals(i + 1L, a[i, j], "Expected element at [$i:$j] to be ${i + 1}")
                 else
                     assertEquals(0L, a[i, j], "Expected non-diagonal elements to be 0")
             }
@@ -666,6 +754,28 @@ class Create2DArrayTests {
     }
 
     /**
+     * Tests the function 'mk.diagonal<Float>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalFloatMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { it + 1f }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals(i + 1f, a[i, j], "Expected element at [$i:$j] to be ${i + 1}")
+                else
+                    assertEquals(0.0f, a[i, j], "Expected non-diagonal elements to be 0.0")
+            }
+        }
+    }
+
+    /**
      * Creates a two-dimensional array from a list of float lists
      * and checks if the array's list representation matches the input list.
      */
@@ -807,6 +917,28 @@ class Create2DArrayTests {
             for (j in 0 until n) {
                 if (i == j)
                     assertEquals(1.0, a[i, j], "Expected diagonal elements to be 1.0")
+                else
+                    assertEquals(0.0, a[i, j], "Expected non-diagonal elements to be 0.0")
+            }
+        }
+    }
+
+    /**
+     * Tests the function 'mk.diagonal<Double>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalDoubleMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { it + 1.0 }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals(i + 1.0, a[i, j], "Expected element at [$i:$j] to be ${i + 1}")
                 else
                     assertEquals(0.0, a[i, j], "Expected non-diagonal elements to be 0.0")
             }
@@ -965,6 +1097,28 @@ class Create2DArrayTests {
     }
 
     /**
+     * Tests the function 'mk.diagonal<ComplexFloat>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalComplexFloatMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { ComplexFloat(it + 1f, it + 1f) }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals(ComplexFloat(i + 1f, i + 1f), a[i, j], "Expected element at [$i:$j] to be ${ComplexFloat(i + 1f, i + 1f)}")
+                else
+                    assertEquals(ComplexFloat.zero, a[i, j], "Expected non-diagonal elements to be ${ComplexFloat.zero}")
+            }
+        }
+    }
+
+    /**
      * Creates a two-dimensional array from a list of complex float lists
      * and checks if the array's list representation matches the input list.
      */
@@ -1089,6 +1243,28 @@ class Create2DArrayTests {
                         a[i, j],
                         "Expected non-diagonal elements to be ${ComplexDouble.zero}"
                     )
+            }
+        }
+    }
+
+    /**
+     * Tests the function 'mk.diagonal<ComplexDouble>(elements)' that creates an identity matrix of size elements.size x elements.size.
+     * The test asserts that:
+     * - The size of the resulting matrix matches elements.size x elements.size.
+     * - The diagonal elements of the matrix are as provided and the non-diagonal elements are 0.
+     */
+    @Test
+    fun createDiagonalComplexDoubleMatrix() {
+        val n = 7
+        val a = mk.diagonal(*List(n) { ComplexDouble(it + 1.0, it + 1.0) }.toTypedArray())
+
+        assertEquals(n * n, a.size)
+        for (i in 0 until n) {
+            for (j in 0 until n) {
+                if (i == j)
+                    assertEquals(ComplexDouble(i + 1.0, i + 1.0), a[i, j], "Expected element at [$i:$j] to be ${ComplexDouble(i + 1.0, i + 1.0)}")
+                else
+                    assertEquals(ComplexDouble.zero, a[i, j], "Expected non-diagonal elements to be ${ComplexDouble.zero}")
             }
         }
     }

--- a/multik-core/src/commonTest/kotlin/samples/creation.kt
+++ b/multik-core/src/commonTest/kotlin/samples/creation.kt
@@ -166,7 +166,7 @@ class NDArrayTest {
 
     @Test
     fun diagonal() {
-        val diagNDArray = mk.diagonal(2, 4, 8)
+        val diagNDArray = mk.diagonal(mk[2, 4, 8])
         println(diagNDArray)
         /*
         [[2, 0, 0],
@@ -177,7 +177,7 @@ class NDArrayTest {
 
     @Test
     fun diagonalWithDtype() {
-        val diagNDArray = mk.diagonal(dtype=DataType.LongDataType, 2, 4, 8)
+        val diagNDArray = mk.diagonal(mk[2, 4, 8], DataType.LongDataType)
         println(diagNDArray)
         /*
         [[2, 0, 0],

--- a/multik-core/src/commonTest/kotlin/samples/creation.kt
+++ b/multik-core/src/commonTest/kotlin/samples/creation.kt
@@ -165,6 +165,28 @@ class NDArrayTest {
     }
 
     @Test
+    fun diagonal() {
+        val diagNDArray = mk.diagonal(2, 4, 8)
+        println(diagNDArray)
+        /*
+        [[2, 0, 0],
+        [0, 4, 0],
+        [0, 0, 8]]
+         */
+    }
+
+    @Test
+    fun diagonalWithDtype() {
+        val diagNDArray = mk.diagonal(dtype=DataType.LongDataType, 2, 4, 8)
+        println(diagNDArray)
+        /*
+        [[2, 0, 0],
+        [0, 4, 0],
+        [0, 0, 8]]
+         */
+    }
+
+    @Test
     fun ndarray1D() {
         val ndarray = mk.ndarray(mk[1, 2, 3])
         println("shape=(${ndarray.shape.joinToString()}), dim=${ndarray.dim.d}") // shape=(3), dim=1


### PR DESCRIPTION
Adding creators for diagonal matrices.
First thought was to name it `diag()` for short, like in numpy, but since `identity()` already departs form numpy's `eye()`, I thought I better use the full word here too.