### PR TITLE
Fix: meanDN return type changed from D4 to DN (fixes #254)

### DIFF
--- a/docs/topics/apiDocs/descriptive-statistics.md
+++ b/docs/topics/apiDocs/descriptive-statistics.md
@@ -50,7 +50,7 @@ Dimension-specific overloads are also available:
 fun <T : Number> Statistics.meanD2(a: MultiArray<T, D2>, axis: Int): NDArray<Double, D1>
 fun <T : Number> Statistics.meanD3(a: MultiArray<T, D3>, axis: Int): NDArray<Double, D2>
 fun <T : Number> Statistics.meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3>
-fun <T : Number> Statistics.meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4>
+fun <T : Number> Statistics.meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN>
 ```
 
 ### Parameters

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/stat/Statistics.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/stat/Statistics.kt
@@ -52,7 +52,7 @@ public interface Statistics {
     /**
      * Returns the arithmetic mean of the n-dimensional ndarray [a] elements along the given [axis].
      */
-    public fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4>
+    public fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN>
 }
 
 /**

--- a/multik-default/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/default/stat/DefaultStatistics.kt
+++ b/multik-default/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/default/stat/DefaultStatistics.kt
@@ -23,5 +23,5 @@ public expect object DefaultStatistics : Statistics {
 
     override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3>
 
-    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4>
+    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN>
 }

--- a/multik-default/src/desktopMain/kotlin/org.jetbrains.kotlinx.multik.default/stat/DefaultStatistics.kt
+++ b/multik-default/src/desktopMain/kotlin/org.jetbrains.kotlinx.multik.default/stat/DefaultStatistics.kt
@@ -31,5 +31,5 @@ public actual object DefaultStatistics : Statistics {
 
     actual override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
+    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> = mean(a, axis)
 }

--- a/multik-default/src/iosMain/kotlin/org.jetbrains.kotlinx.multik.default/stat/DefaultStatistics.kt
+++ b/multik-default/src/iosMain/kotlin/org.jetbrains.kotlinx.multik.default/stat/DefaultStatistics.kt
@@ -29,5 +29,5 @@ public actual object DefaultStatistics : Statistics {
 
     actual override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
+    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> = mean(a, axis)
 }

--- a/multik-default/src/jsMain/kotlin/org.jetbrains.kotlinx.multik.default/stat/DefaultStatistics.kt
+++ b/multik-default/src/jsMain/kotlin/org.jetbrains.kotlinx.multik.default/stat/DefaultStatistics.kt
@@ -29,5 +29,5 @@ public actual object DefaultStatistics : Statistics {
 
     actual override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
+    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> = mean(a, axis)
 }

--- a/multik-default/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/default/stat/DefaultStatistics.kt
+++ b/multik-default/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/default/stat/DefaultStatistics.kt
@@ -31,5 +31,5 @@ public actual object DefaultStatistics : Statistics {
 
     actual override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
+    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> = mean(a, axis)
 }

--- a/multik-default/src/wasmJsMain/kotlin/org/jetbrains/kotlinx/multik/default/stat/DefaultStatistics.kt
+++ b/multik-default/src/wasmJsMain/kotlin/org/jetbrains/kotlinx/multik/default/stat/DefaultStatistics.kt
@@ -29,5 +29,5 @@ public actual object DefaultStatistics : Statistics {
 
     actual override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
+    actual override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> = mean(a, axis)
 }

--- a/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/stat/KEStatistics.kt
+++ b/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/stat/KEStatistics.kt
@@ -72,5 +72,5 @@ internal object KEStatistics : Statistics {
 
     override fun <T : Number> meanD4(a: MultiArray<T, D4>, axis: Int): NDArray<Double, D3> = mean(a, axis)
 
-    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> = mean(a, axis)
+    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> = mean(a, axis)
 }

--- a/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/statistics/KEStatisticsTest.kt
+++ b/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/statistics/KEStatisticsTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlinx.multik.api.arange
 import org.jetbrains.kotlinx.multik.api.mk
 import org.jetbrains.kotlinx.multik.api.ndarray
 import org.jetbrains.kotlinx.multik.kotlin.stat.KEStatistics
+import org.jetbrains.kotlinx.multik.ndarray.data.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -55,5 +56,20 @@ class KEStatisticsTest {
     fun test_of_mean_function_on_a_2d_ndarray() {
         val ndarray = mk.ndarray(mk[mk[1, 2], mk[3, 4]])
         assertEquals(2.5, KEStatistics.mean(ndarray))
+    }
+
+    @Test
+    fun test_meanDN_returns_DN_dimension() {
+        // Create a 5D array (DN dimension) with shape [2, 2, 2, 2, 2]
+        val shape = intArrayOf(2, 2, 2, 2, 2)
+        val memoryView = initMemoryView<Int>(32, DataType.IntDataType) { it }
+        val ndarray = NDArray(memoryView, shape = shape, dim = DN(5))
+
+        // meanDN along axis 0 should return NDArray<Double, DN>, not NDArray<Double, D4>
+        val result: NDArray<Double, DN> = KEStatistics.meanDN(ndarray, axis = 0)
+
+        // Verify the result shape: removing axis 0 from [2,2,2,2,2] gives [2,2,2,2]
+        assertEquals(4, result.shape.size)
+        assertEquals(intArrayOf(2, 2, 2, 2).toList(), result.shape.toList())
     }
 }

--- a/multik-openblas/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/openblas/stat/NativeStatistics.kt
+++ b/multik-openblas/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/openblas/stat/NativeStatistics.kt
@@ -47,7 +47,7 @@ internal object NativeStatistics : Statistics {
         TODO("Not yet implemented")
     }
 
-    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, D4> {
+    override fun <T : Number> meanDN(a: MultiArray<T, DN>, axis: Int): NDArray<Double, DN> {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Summary
Fixes #254

**Bug:** `meanDN` declared return type `NDArray<Double, D4>` instead of `NDArray<Double, DN>`, causing incorrect typing for n-dimensional arrays (5D+).

## Changes
- Fixed return type from `D4` to `DN` in `Statistics` interface and all implementations (KEStatistics, NativeStatistics, DefaultStatistics across jvm/js/ios/desktop/wasmJs/common)
- Updated documentation in `descriptive-statistics.md`
- Added regression test `test_meanDN_returns_DN_dimension` in `KEStatisticsTest`

## Files Modified (11)
| Module | File | Change |
|--------|------|--------|
| multik-core | Statistics.kt | D4 -> DN in interface |
| multik-kotlin | KEStatistics.kt | D4 -> DN |
| multik-openblas | NativeStatistics.kt | D4 -> DN |
| multik-default | DefaultStatistics.kt x6 platforms | D4 -> DN |
| docs | descriptive-statistics.md | D4 -> DN |
| multik-kotlin (test) | KEStatisticsTest.kt | New regression test |

## Testing
New test creates a 5D NDArray, calls `meanDN(axis=0)`, and verifies the result is correctly typed as `NDArray<Double, DN>` with shape [2,2,2,2].