### PR TITLE
fix: include iOS targets in multik-default publication (#304)

### DIFF
--- a/buildSrc/src/main/kotlin/multik.host-native-kmp.gradle.kts
+++ b/buildSrc/src/main/kotlin/multik.host-native-kmp.gradle.kts
@@ -24,28 +24,32 @@ kotlin {
 }
 
 val hostTargetName = (project.extra["hostNativeTarget"] as KotlinNativeTarget).name
-val allNativeTargetNames = kotlin.targets.withType<KotlinNativeTarget>().map { it.name }
+
+// Targets that need host-gating because of CInterop/CMake JNI (see multik-openblas).
+// iOS/JS/WASM are pure Kotlin and follow standard KMP rules — Kotlin disables unsupported
+// host compilations itself, and non-desktop klibs should publish normally from the main host.
+val gatedTargetNames = listOf("macosArm64", "macosX64", "linuxX64", "mingwX64")
 
 // multik.mainHost (Gradle property, default=true):
-//   true  → main host: publishes everything except non-host native
+//   true  → main host: publishes everything except non-host gated native
 //   false → platform runner: publishes only host native klib
 val isMainHost = (findProperty("multik.mainHost") as? String)?.toBoolean() ?: true
 
 tasks.configureEach {
     when (this) {
         is KotlinNativeCompile, is KotlinNativeLink -> {
-            val isNonHost = allNativeTargetNames
+            val isNonHostGated = gatedTargetNames
                 .filter { it != hostTargetName }
                 .any { name.contains(it, ignoreCase = true) }
-            if (isNonHost) enabled = false
+            if (isNonHostGated) enabled = false
         }
 
         is AbstractPublishToMaven, is GenerateModuleMetadata -> {
             if (isMainHost) {
-                val isNonHostNative = allNativeTargetNames
+                val isNonHostGated = gatedTargetNames
                     .filter { it != hostTargetName }
                     .any { name.contains(it, ignoreCase = true) }
-                if (isNonHostNative) enabled = false
+                if (isNonHostGated) enabled = false
             } else {
                 val isHostNative = name.contains(hostTargetName, ignoreCase = true)
                 if (!isHostNative) enabled = false


### PR DESCRIPTION
## Summary

- `multik.host-native-kmp` was gating **all** `KotlinNativeTarget`s as host-dependent, silently dropping `iosArm64` / `iosSimulatorArm64` / `iosX64` klibs from the `multik-default` main-host publication (observed in 0.3.0).
- The gating only exists to keep CInterop/CMake JNI work pinned to the matching host. Narrow it to the four desktop targets that actually need it (`macosArm64`, `macosX64`, `linuxX64`, `mingwX64`). iOS (and future JS/WASM native-style targets) now follow standard KMP rules: Kotlin itself disables unsupported-host compiles, and iOS klibs publish normally from the main host.

Fixes #304.

## Test plan

- [x] `./gradlew :multik-default:publishIosArm64PublicationToMavenLocal :multik-default:publishIosSimulatorArm64PublicationToMavenLocal :multik-default:publishIosX64PublicationToMavenLocal` — BUILD SUCCESSFUL; `.klib` / `.module` / `.pom` present under `~/.m2/repository/org/jetbrains/kotlinx/multik-default-ios{arm64,simulatorarm64,x64}/0.3.0/`.
- [x] Regression: `./gradlew :multik-openblas:compileKotlinMacosX64 :multik-openblas:compileKotlinLinuxX64 :multik-openblas:compileKotlinMingwX64` — all `SKIPPED` on a macosArm64 host (host-gating still works for desktop targets).
- [x] `./gradlew :multik-openblas:compileKotlinMacosArm64` — runs (host target).
- [x] `./gradlew assemble` — BUILD SUCCESSFUL.