### PR TITLE
build: resolve cmake executable at configuration time

### DIFF
--- a/buildSrc/src/main/kotlin/multik.cmake-build.gradle.kts
+++ b/buildSrc/src/main/kotlin/multik.cmake-build.gradle.kts
@@ -1,9 +1,11 @@
+import org.jetbrains.kotlinx.multik.builds.CmakeDetection
 import org.jetbrains.kotlinx.multik.builds.HomebrewGccDetection
 import org.jetbrains.kotlinx.multik.builds.HostDetection
 
 val cmakePath = "${rootDir}/multik-openblas/multik_jni"
 val cmakeBuildDir = layout.buildDirectory.dir("cmake-build").map { it.asFile.absolutePath }
 
+val cmakeExecutable = CmakeDetection.executable
 val cmakeCCompiler = System.getenv("CMAKE_C_COMPILER")
     ?: HomebrewGccDetection.cCompiler
     ?: "gcc"
@@ -26,7 +28,7 @@ val configureCmake by tasks.registering(Exec::class) {
     dependsOn(createBuildDir)
 
     val args = mutableListOf(
-        "cmake",
+        cmakeExecutable,
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_C_COMPILER=$cmakeCCompiler",
         "-DCMAKE_CXX_COMPILER=$cmakeCxxCompiler",
@@ -46,7 +48,7 @@ val compileCmake by tasks.registering(Exec::class) {
     dependsOn(configureCmake)
 
     val processors = Runtime.getRuntime().availableProcessors().toString()
-    commandLine("cmake", "--build", cmakeBuildDir.get(), "--target", "multik_jni-$targetOS", "--", "-j", processors)
+    commandLine(cmakeExecutable, "--build", cmakeBuildDir.get(), "--target", "multik_jni-$targetOS", "--", "-j", processors)
 }
 
 val copyNativeLibs by tasks.registering {

--- a/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/CmakeDetection.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/CmakeDetection.kt
@@ -14,9 +14,9 @@ object CmakeDetection {
 
     /** Absolute path to `cmake`, or plain `"cmake"` as a last resort. */
     val executable: String by lazy {
-        System.getenv("CMAKE")?.takeIf { File(it).canExecute() }
+        System.getenv("CMAKE")?.let(::File)?.takeIf { it.isFile && it.canExecute() }?.absolutePath
             ?: findOnPath()
-            ?: commonInstallPaths.firstOrNull { File(it).canExecute() }
+            ?: commonInstallPaths.map(::File).firstOrNull { it.isFile && it.canExecute() }?.absolutePath
             ?: "cmake"
     }
 
@@ -39,7 +39,7 @@ object CmakeDetection {
             if (dir.isEmpty()) continue
             for (name in exeNames) {
                 val candidate = File(dir, name)
-                if (candidate.canExecute()) return candidate.absolutePath
+                if (candidate.isFile && candidate.canExecute()) return candidate.absolutePath
             }
         }
         return null

--- a/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/CmakeDetection.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/CmakeDetection.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.kotlinx.multik.builds
+
+import java.io.File
+
+/**
+ * Resolves an absolute path to the `cmake` executable.
+ *
+ * The `cmake` Gradle tasks run as `Exec` and inherit the PATH of whatever process launched Gradle.
+ * GUI-launched IDEs on macOS don't pick up Homebrew's `/opt/homebrew/bin`, so `commandLine("cmake", ...)`
+ * can fail with "Cannot run program 'cmake'" even when the binary is installed. Resolving to an
+ * absolute path at configuration time sidesteps PATH inheritance entirely.
+ */
+object CmakeDetection {
+
+    /** Absolute path to `cmake`, or plain `"cmake"` as a last resort. */
+    val executable: String by lazy {
+        System.getenv("CMAKE")?.takeIf { File(it).canExecute() }
+            ?: findOnPath()
+            ?: commonInstallPaths.firstOrNull { File(it).canExecute() }
+            ?: "cmake"
+    }
+
+    private val commonInstallPaths: List<String> = when {
+        HostDetection.isMacosArm64 -> listOf("/opt/homebrew/bin/cmake", "/usr/local/bin/cmake")
+        HostDetection.isMacosX64 -> listOf("/usr/local/bin/cmake", "/opt/homebrew/bin/cmake")
+        HostDetection.isLinux -> listOf("/usr/bin/cmake", "/usr/local/bin/cmake")
+        HostDetection.isWindows -> listOf(
+            "C:\\Program Files\\CMake\\bin\\cmake.exe",
+            "C:\\Program Files (x86)\\CMake\\bin\\cmake.exe"
+        )
+        else -> emptyList()
+    }
+
+    private fun findOnPath(): String? {
+        val path = System.getenv("PATH") ?: return null
+        val separator = File.pathSeparator
+        val exeNames = if (HostDetection.isWindows) listOf("cmake.exe", "cmake") else listOf("cmake")
+        for (dir in path.split(separator)) {
+            if (dir.isEmpty()) continue
+            for (name in exeNames) {
+                val candidate = File(dir, name)
+                if (candidate.canExecute()) return candidate.absolutePath
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
## Summary

- When Gradle is launched from a GUI IDE on macOS (e.g. IntelliJ started via Spotlight/Dock), the Gradle daemon does not inherit Homebrew's `/opt/homebrew/bin` in `PATH`. The `configure_cmake` / `compile_cmake` Exec tasks invoke `commandLine("cmake", ...)` and fail with `Cannot run program 'cmake'`, even when cmake is installed.
- Resolve the `cmake` binary to an **absolute** path at configuration time via a new `CmakeDetection` helper:
  1. `$CMAKE` env var, if set and executable.
  2. Walk `$PATH` for the `cmake` (or `cmake.exe`) binary.
  3. Fall back to common install locations per platform (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `C:\Program Files\CMake\bin\cmake.exe`, …).
  4. Last-resort: plain `"cmake"` (preserves current behaviour on unusual setups).
- Updates `multik.cmake-build.gradle.kts` to use the resolved executable everywhere.

No behaviour change for CI (`gcc/cmake` are on PATH there); fixes the "works in terminal, fails in IDE" gotcha locally.

## Test plan

- [x] `./gradlew :multik-openblas:build_cmake` from a terminal shell — still works.
- [ ] Reproduce the original failure: launch IDEA from Dock (no Homebrew PATH inherited) and run `:multik-openblas:build_cmake` — previously failed, now picks up `/opt/homebrew/bin/cmake`.
- [ ] `CMAKE=/some/other/cmake ./gradlew :multik-openblas:configureCmake` — honours the env override.