### PR TITLE
build: use indirect ccall mode in multik-openblas cinterop

### DIFF
--- a/multik-openblas/build.gradle.kts
+++ b/multik-openblas/build.gradle.kts
@@ -65,6 +65,8 @@ kotlin {
                         compilerOpts("-DFORCE_OPENBLAS_COMPLEX_STRUCT=1")
                     }
 
+                    extraOpts("-Xccall-mode", "indirect")
+
                     extraOpts("-Xsource-compiler-option", "-std=c++14")
                     extraOpts("-Xsource-compiler-option", "-I$headersDir")
                     extraOpts("-Xsource-compiler-option", "-I$openblasIncludeDir")


### PR DESCRIPTION
## Summary

- Add `extraOpts("-Xccall-mode", "indirect")` to the host-target cinterop block in `multik-openblas`.
- `-Xccall-mode indirect` switches Kotlin/Native C-call generation to indirect dispatch (function-pointer lookup) instead of the direct `ccall` mode. This decouples the Kotlin/Native consumer from direct link-time symbol resolution against OpenBLAS and the `multik_jni` C++ sources — resolution happens at runtime.

## Test plan

- [x] `./gradlew :multik-openblas:compileKotlinMacosArm64` — BUILD SUCCESSFUL on macOS ARM64 host.
- [x] `./gradlew assemble` — BUILD SUCCESSFUL.
- [ ] Verify on Linux CI runner (`./gradlew :multik-openblas:compileKotlinLinuxX64` with `-Pmultik.mainHost=false`).