### PR TITLE
build: drop macosX64 Kotlin/Native target

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -24,7 +24,6 @@ on:
           - all
           - linuxX64
           - macosArm64
-          - macosX64
           - mingwX64
           - androidArm64
 
@@ -147,67 +146,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: native-macosArm64
-          path: |
-            build/cmake-build/libmultik_jni-*
-            build/cmake-build/openblas-install/include/
-            build/cmake-build/openblas-install/lib/libopenblas.a
-          retention-days: 90
-
-  # ── macOS x86_64 ─────────────────────────────────────────────
-  build-macosX64:
-    name: macOS x64
-    if: >-
-      github.event_name != 'workflow_dispatch' ||
-      github.event.inputs.platform == 'all' ||
-      github.event.inputs.platform == 'macosX64'
-    runs-on: macos-26-intel
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install build dependencies
-        run: brew install gcc cmake
-
-      - name: Setup JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - name: Detect Homebrew GCC
-        run: |
-          BREW_GCC_PREFIX=$(brew --prefix gcc)
-          GCC_VER=$(ls "$BREW_GCC_PREFIX/bin/" | grep -oE '^gcc-[0-9]+$' | sort -t- -k2 -n | tail -1 | cut -d- -f2)
-          echo "CC=$BREW_GCC_PREFIX/bin/gcc-$GCC_VER" >> "$GITHUB_ENV"
-          echo "CXX=$BREW_GCC_PREFIX/bin/g++-$GCC_VER" >> "$GITHUB_ENV"
-          echo "$BREW_GCC_PREFIX/bin" >> "$GITHUB_PATH"
-
-      - name: Cache OpenBLAS build
-        uses: actions/cache@v5
-        with:
-          path: build/cmake-build/openblas*
-          key: openblas-macosX64-${{ hashFiles('multik-openblas/multik_jni/CMakeLists.txt') }}
-          restore-keys: |
-            openblas-macosX64-
-
-      - name: Configure CMake
-        run: |
-          cmake \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER="$CC" \
-            -DCMAKE_CXX_COMPILER="$CXX" \
-            -DTARGET_OS=macosX64 \
-            -S multik-openblas/multik_jni \
-            -B build/cmake-build
-
-      - name: Build native library
-        run: cmake --build build/cmake-build --target multik_jni-macosX64 -- -j "$(sysctl -n hw.ncpu)"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: native-macosX64
           path: |
             build/cmake-build/libmultik_jni-*
             build/cmake-build/openblas-install/include/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Import stable `multik` version into notebook:
 |      **WasmJS**       |       ✅       |        ✅        |         —         |        ✅         |
 |     **linuxX64**      |       ✅       |        ✅        |         ✅         |        ✅         |
 |     **mingwX64**      |       ✅       |        ✅        |         ✅         |        ✅         |
-|     **macosX64**      |       ✅       |        ✅        |         ✅         |        ✅         |
 |    **macosArm64**     |       ✅       |        ✅        |         ✅         |        ✅         |
 |     **iosArm64**      |       ✅       |        ✅        |         —         |        ✅         |
 |      **iosX64**       |       ✅       |        ✅        |         —         |        ✅         |
@@ -107,7 +106,7 @@ Import stable `multik` version into notebook:
 
 > [!IMPORTANT]
 > - On Linux distributions with **glibc** older than 2.31, `multik-openblas` doesn't work.
-> - `multik-openblas` for desktop native targets (_linuxX64_, _mingwX64_, _macosX64_, _macosArm64_) is experimental and
+> - `multik-openblas` for desktop native targets (_linuxX64_, _mingwX64_, _macosArm64_) is experimental and
 > unstable.
 > - JVM target `multik-openblas` for Android only supports **arm64-v8a** processors.
 

--- a/buildSrc/src/main/kotlin/multik.all-targets-kmp.gradle.kts
+++ b/buildSrc/src/main/kotlin/multik.all-targets-kmp.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 kotlin {
     mingwX64()
     linuxX64()
-    macosX64()
     macosArm64()
 
     iosArm64()

--- a/buildSrc/src/main/kotlin/multik.host-native-kmp.gradle.kts
+++ b/buildSrc/src/main/kotlin/multik.host-native-kmp.gradle.kts
@@ -10,12 +10,10 @@ plugins {
 
 kotlin {
     macosArm64()
-    macosX64()
     linuxX64()
     mingwX64()
 
     val hostTarget = when (HostDetection.currentTarget) {
-        MultikNativeTarget.MACOS_X64 -> targets.getByName("macosX64")
         MultikNativeTarget.MACOS_ARM64 -> targets.getByName("macosArm64")
         MultikNativeTarget.LINUX_X64 -> targets.getByName("linuxX64")
         MultikNativeTarget.MINGW_X64 -> targets.getByName("mingwX64")
@@ -28,7 +26,7 @@ val hostTargetName = (project.extra["hostNativeTarget"] as KotlinNativeTarget).n
 // Targets that need host-gating because of CInterop/CMake JNI (see multik-openblas).
 // iOS/JS/WASM are pure Kotlin and follow standard KMP rules — Kotlin disables unsupported
 // host compilations itself, and non-desktop klibs should publish normally from the main host.
-val gatedTargetNames = listOf("macosArm64", "macosX64", "linuxX64", "mingwX64")
+val gatedTargetNames = listOf("macosArm64", "linuxX64", "mingwX64")
 
 // multik.mainHost (Gradle property, default=true):
 //   true  → main host: publishes everything except non-host gated native

--- a/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/CmakeDetection.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/CmakeDetection.kt
@@ -22,7 +22,6 @@ object CmakeDetection {
 
     private val commonInstallPaths: List<String> = when {
         HostDetection.isMacosArm64 -> listOf("/opt/homebrew/bin/cmake", "/usr/local/bin/cmake")
-        HostDetection.isMacosX64 -> listOf("/usr/local/bin/cmake", "/opt/homebrew/bin/cmake")
         HostDetection.isLinux -> listOf("/usr/bin/cmake", "/usr/local/bin/cmake")
         HostDetection.isWindows -> listOf(
             "C:\\Program Files\\CMake\\bin\\cmake.exe",

--- a/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/HomebrewGccDetection.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/HomebrewGccDetection.kt
@@ -50,5 +50,5 @@ object HomebrewGccDetection {
         if (current != null && current.isDirectory) current.absolutePath else null
     }
 
-    private val isMacos: Boolean get() = HostDetection.isMacosX64 || HostDetection.isMacosArm64
+    private val isMacos: Boolean get() = HostDetection.isMacosArm64
 }

--- a/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/HostDetection.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/kotlinx/multik/builds/HostDetection.kt
@@ -3,7 +3,6 @@ package org.jetbrains.kotlinx.multik.builds
 import org.gradle.api.GradleException
 
 enum class MultikNativeTarget(val targetName: String) {
-    MACOS_X64("macosX64"),
     MACOS_ARM64("macosArm64"),
     LINUX_X64("linuxX64"),
     MINGW_X64("mingwX64"),
@@ -13,21 +12,19 @@ object HostDetection {
     val hostOs: String = System.getProperty("os.name")
     val hostArch: String = System.getProperty("os.arch")
 
-    val isMacosX64: Boolean get() = hostOs == "Mac OS X" && hostArch == "x86_64"
     val isMacosArm64: Boolean get() = hostOs == "Mac OS X" && hostArch == "aarch64"
     val isLinux: Boolean get() = hostOs == "Linux"
     val isWindows: Boolean get() = hostOs.startsWith("Windows")
 
     val currentTarget: MultikNativeTarget
         get() = when {
-            isMacosX64 -> MultikNativeTarget.MACOS_X64
             isMacosArm64 -> MultikNativeTarget.MACOS_ARM64
             isLinux -> MultikNativeTarget.LINUX_X64
             isWindows -> MultikNativeTarget.MINGW_X64
             else -> throw GradleException(
                 """
                 Failed to detect platform. Supported platforms:
-                    macosX64, macosArm64, linuxX64, mingwX64
+                    macosArm64, linuxX64, mingwX64
                 """.trimIndent()
             )
         }

--- a/docs/topics/gettingStarted/multik-on-desktop.md
+++ b/docs/topics/gettingStarted/multik-on-desktop.md
@@ -28,7 +28,7 @@ Both can use the same Multik API, with engine choice depending on platform and p
 | Target                                                            | Engines                            | Notes                                                             |
 |-------------------------------------------------------------------|------------------------------------|-------------------------------------------------------------------|
 | JVM desktop                                                       | DEFAULT, KOTLIN, NATIVE (OpenBLAS) | NATIVE requires `multik-openblas`.                                |
-| Native desktop (`linuxX64`, `mingwX64`, `macosX64`, `macosArm64`) | KOTLIN; NATIVE (OpenBLAS)          | OpenBLAS for desktop native targets is experimental and unstable. |
+| Native desktop (`linuxX64`, `mingwX64`, `macosArm64`)             | KOTLIN; NATIVE (OpenBLAS)          | OpenBLAS for desktop native targets is experimental and unstable. |
 
 ## Dependencies
 

--- a/docs/topics/gettingStarted/multik-on-different-platforms.md
+++ b/docs/topics/gettingStarted/multik-on-different-platforms.md
@@ -37,7 +37,7 @@ The following [target presets](https://kotlinlang.org/docs/multiplatform-dsl-ref
 |-----------------|-------------------------------------------|
 | Kotlin/JVM      | `jvm`                                     |
 | iOS             | `iosArm64`, `iosX64`, `iosSimulatorArm64` |
-| macOS           | `macosX64`, `macosArm64`                  |
+| macOS           | `macosArm64`                              |
 | Linux           | `linuxX64`                                |
 | Windows         | `mingwX64`                                |
 | JS              | `js`                                      |
@@ -56,7 +56,7 @@ Multik separates the API from execution engines:
 | JVM              | DEFAULT, KOTLIN, NATIVE (OpenBLAS)            | NATIVE requires the OpenBLAS artifact.                                                                               |
 | JS               | KOTLIN                                        | Browser and Node.js targets.                                                                                         |
 | WASM             | KOTLIN                                        | Kotlin/WASM targets.                                                                                                 |
-| Native (desktop) | KOTLIN; NATIVE (OpenBLAS) on selected targets | OpenBLAS for desktop native targets (`linuxX64`, `mingwX64`, `macosX64`, `macosArm64`) is experimental and unstable. |
+| Native (desktop) | KOTLIN; NATIVE (OpenBLAS) on selected targets | OpenBLAS for desktop native targets (`linuxX64`, `mingwX64`, `macosArm64`) is experimental and unstable.            |
 | Native (iOS)     | KOTLIN                                        | OpenBLAS is not available.                                                                                           |
 
 For details such as Android ABI limits, see the platform pages below.

--- a/multik-default/build.gradle.kts
+++ b/multik-default/build.gradle.kts
@@ -34,11 +34,9 @@ kotlin {
         val desktopTest by creating { dependsOn(commonTest.get()) }
 
         getByName("macosArm64Main").dependsOn(desktopMain)
-        getByName("macosX64Main").dependsOn(desktopMain)
         getByName("linuxX64Main").dependsOn(desktopMain)
         getByName("mingwX64Main").dependsOn(desktopMain)
         getByName("macosArm64Test").dependsOn(desktopTest)
-        getByName("macosX64Test").dependsOn(desktopTest)
         getByName("linuxX64Test").dependsOn(desktopTest)
         getByName("mingwX64Test").dependsOn(desktopTest)
     }

--- a/multik-openblas/build.gradle.kts
+++ b/multik-openblas/build.gradle.kts
@@ -34,10 +34,6 @@ kotlin {
                 into("lib/macosArm64")
             }
             from("$projectDir/build/libs") {
-                include("libmultik_jni-macosX64.dylib")
-                into("lib/macosX64")
-            }
-            from("$projectDir/build/libs") {
                 include("libmultik_jni-mingwX64.dll")
                 into("lib/mingwX64")
             }

--- a/multik-openblas/multik_jni/CMakeLists.txt
+++ b/multik-openblas/multik_jni/CMakeLists.txt
@@ -48,12 +48,6 @@ elseif (${TARGET_OS} STREQUAL "macosArm64" OR ${PLATFORM} MATCHES "Darwin-arm64"
     set(FEXTRALIB "-lgfortran")
     set(NO_AVX512 1)
     set(DYNAMIC_ARCH 1)
-elseif(${TARGET_OS} STREQUAL "macosX64" OR ${PLATFORM} MATCHES "Darwin-x86_64")
-    set(suffix macosX64)
-    set(FC "gfortran")
-    set(FEXTRALIB "-lgfortran")
-    set(NO_AVX512 0)
-    set(DYNAMIC_ARCH 1)
 # linuxArm64: uncomment when needed
 # elseif(${TARGET_OS} STREQUAL "linuxArm64")
 #     set(suffix linuxArm64)

--- a/multik-openblas/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/openblas/Loader.kt
+++ b/multik-openblas/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/openblas/Loader.kt
@@ -53,13 +53,7 @@ internal class JvmLoader(private val name: String) : Loader {
     private val prefixPath = when (os) {
         "android" -> "lib/arm64-v8a/"
         "linux" -> "lib/linuxX64/"
-        "macos" -> {
-            if (arch == "Arm64")
-                "lib/macosArm64/"
-            else
-                "lib/macosX64/"
-        }
-
+        "macos" -> "lib/macosArm64/"
         else -> "lib/mingwX64/"
     }
 


### PR DESCRIPTION
## Summary

- Drops the `macosX64` Kotlin/Native target from every module, CI, docs, and host-detection helpers. Apple has wound down Intel Macs and the target is obsolete — this aligns the build matrix with what we actually support.
- Removes the dedicated `macos-26-intel` CI job (`build-macosX64` in `build-native.yml`) along with its `workflow_dispatch` option.
- Simplifies the JVM `Loader.kt` macOS branch to `lib/macosArm64/` and strips `MACOS_X64` / `isMacosX64` from the buildSrc host-detection helpers. `HomebrewGccDetection.isMacos` now just delegates to `isMacosArm64`.

**Breaking:** downstream consumers depending on the `*-macosx64` classifier artifacts will no longer receive new publications. Multik is alpha-stability (JetBrains incubator), so no `@Deprecated` staging was used.

## Test plan

- [x] `./gradlew projects` — configuration succeeds across all modules
- [x] `./gradlew :multik-core:compileKotlinJvm :multik-kotlin:compileKotlinJvm :multik-default:compileKotlinJvm` — green
- [x] `./gradlew :multik-core:compileKotlinMacosArm64 :multik-kotlin:compileKotlinMacosArm64 :multik-default:compileKotlinMacosArm64` — green
- [x] `grep -r "macosX64\|MACOS_X64\|isMacosX64" .` returns no hits
- [x] `./gradlew :multik-openblas:tasks --all | grep -i macos` shows only `macosArm64` tasks
- [ ] CI: `Build & Test` on Ubuntu passes
- [ ] CI: `Build Native Libraries` (manual `workflow_dispatch`) no longer lists `macosX64` and still builds the remaining platforms