### PR TITLE
fix: return views from shape ops, unify error handling across engines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,101 +1,67 @@
-# CLAUDE.md
+# Multik
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Kotlin Multiplatform ndarray library (math, linear algebra, statistics). Alpha, but the public API is
+gated by the binary-compatibility-validator: **any public API change needs `./gradlew apiDump` and a
+deliberate diff review.** Declarations marked `@ExperimentalMultikApi` are excluded from the dump —
+mark new unstable APIs with it.
 
-## Project Overview
+Base PRs against `develop`.
 
-Multik is a Kotlin Multiplatform library for multidimensional arrays (ndarray), providing math, linear algebra, and
-statistics operations. JetBrains incubator project (alpha stability). Group ID: `org.jetbrains.kotlinx`, version defined
-in `gradle.properties`.
+## Modules
 
-## Module Structure
+| Module | Provides | Targets |
+|---|---|---|
+| `multik-core` | ndarray types, the `mk` entry point, `Math`/`LinAlg`/`Statistics` interfaces | all; CSV/NPY IO is JVM-only |
+| `multik-kotlin` | `KEEngine`, pure Kotlin | all |
+| `multik-openblas` | `NativeEngine`, OpenBLAS via C++/JNI (`multik_jni/`) | JVM + desktop Native only — no iOS/JS/WASM |
+| `multik-default` | `DefaultEngine`: `NativeEngine` where available, else `KEEngine` | all |
 
-- **multik-core** — Core ndarray types, the `Multik` (`mk`) entry-point object, and API interfaces (`Math`, `LinAlg`,
-  `Statistics`). All platforms. JVM-only: CSV/NPY IO via `commons-csv` and `bio-npy`.
-- **multik-kotlin** — Pure Kotlin engine (`KEEngine`). JVM + Native + JS + WASM.
-- **multik-openblas** — Native engine (`NativeEngine`) using OpenBLAS via C++/JNI. JVM + desktop Native only (no
-  iOS/JS/WASM). C++ source in `multik-openblas/multik_jni/`.
-- **multik-default** — Combines multik-kotlin and multik-openblas via `DefaultEngine`/`DefaultEngineFactory`. Picks
-  `NativeEngine` on supported platforms, falls back to `KEEngine`.
+Put new APIs in the broadest source set that supports them (`commonMain` first).
 
-## Build Commands
-
-```bash
-# Build all modules (requires: gcc/g++/gfortran 8+, JAVA_HOME set)
-./gradlew assemble
-
-# Build without native OpenBLAS (skip the CMake step)
-./gradlew assemble -x build_cmake
-
-# Build only core module
-./gradlew :multik-core:build
-```
-
-CMake build uses env vars: `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, `GCC_LIB_Path`, `TARGET_OS`.
-Task chain: `createBuildDir` → `configureCmake` → `compileCmake` → `copyNativeLibs` → `build_cmake`.
-
-## Testing
+## Build and test
 
 ```bash
-# JVM tests (JUnit Platform)
+./gradlew assemble                     # needs gcc/g++/gfortran 8+ and JAVA_HOME
+./gradlew assemble -x build_cmake      # skip the native OpenBLAS build
 ./gradlew :multik-core:jvmTest
-./gradlew :multik-kotlin:jvmTest
-./gradlew :multik-openblas:jvmTest   # requires built native lib (build_cmake)
-
-# Single test class
-./gradlew :multik-core:jvmTest --tests "org.jetbrains.kotlinx.multik.creation.Create2DIntArrayTests"
-
-# Native tests (host target only)
-./gradlew :multik-core:macosArm64Test   # or linuxX64Test, mingwX64Test
+./gradlew :multik-core:macosArm64Test  # or linuxX64Test / mingwX64Test
+./gradlew apiCheck korroCheck          # run both before opening a PR
 ```
 
-### Test Conventions
+`:multik-openblas:jvmTest` needs the native library built by `build_cmake`; those tests extend
+`NativeTestBase`, which loads it in `@BeforeTest`.
 
-- Name test functions `testXxx` — no backticks in test names.
-- Test classes use `*Test` / `*Tests` suffix.
-- `multik-openblas` tests extend `NativeTestBase` which calls `libLoader("multik_jni").manualLoad()` in `@BeforeTest`.
-  The JVM test task sets `java.library.path` to `build/cmake-build`.
+Name test functions `testXxx` — no backticks, unlike common Kotlin style.
 
-## Architecture
+## Public API
 
-The `Multik` object (aliased as `mk`) delegates to an `Engine` providing `Math`, `LinAlg`, and `Statistics`.
-Engines: `KEEngine` (pure Kotlin, all platforms), `NativeEngine` (OpenBLAS, JVM + desktop Native),
-`DefaultEngine` (picks best available). Engine loading is platform-specific via `expect fun enginesProvider()`.
+Follow the [Kotlin library guidelines](https://github.com/Kotlin/api-guidelines/tree/main/docs/topics).
+Binary compatibility is the reason behind each of these:
 
-## Code Conventions
+- No data classes in public API — write an explicit `toString`.
+- No new parameters on existing public functions, not even with defaults. Add overloads.
+- Never widen or narrow an existing return type.
+- Deprecate progressively: `@Deprecated` with `message` and `replaceWith`, WARNING → ERROR → HIDDEN.
+- Compose with `NDArray<T, D>` / `MemoryView` / `Engine` instead of adding parallel hierarchies.
+- Document view-vs-copy semantics on anything returning an `NDArray`.
 
-- Kotlin 2.3.10 with `-Xexpect-actual-classes` compiler flag. JVM target: 11.
-- All development happens on the `develop` branch — base PRs against `develop`.
-- Convention plugins in `buildSrc/src/main/kotlin/`.
+## Errors
 
-## API Design Guidelines
+One condition, one exception type, identical in every engine — `multik-default` resolves the engine at
+runtime, so a mismatch between `KEEngine` and `NativeEngine` makes user code platform-dependent.
 
-Follow
-the [Kotlin library authors' guidelines](https://github.com/Kotlin/api-guidelines/tree/main/docs/topics). Key
-Multik-specific rules:
+- Numerical failure on valid input (singular matrix, no convergence) → `ArithmeticException`.
+- No implementation for a dtype, dimension, format, or platform → `UnsupportedOperationException`.
+- `EngineMultikException` is for engine discovery and loading only.
+- LAPACK `info < 0` blames an argument *the wrapper* passed, so it is `check`/`error`, not `require`.
+- Never `throw Exception`. Every message names the offending value — dtype, axis and its bound, shapes.
+- Changing what an existing function throws is behaviour-visible: note it for the release notes.
 
-- **No data classes in public API** — adding properties breaks binary compatibility. Use regular classes with explicit
-  `toString`.
-- **No new arguments on existing public functions**, even with defaults — breaks binary compatibility on JVM. Use manual
-  overloads.
-- **Never widen or narrow return types** of existing public functions.
-- Use `@Deprecated` with `message`, `replaceWith`, and progressive `level` (WARNING → ERROR → HIDDEN).
-- Use `@RequiresOptIn` (e.g. `@ExperimentalMultikApi`) for new unstable APIs.
-- Core model is `NDArray<T, D>` + `MemoryView` + `Engine` — new operations should compose with these, not introduce
-  parallel hierarchies.
-- Place APIs in the broadest relevant source set (`commonMain` first).
+## Docs
 
-## KDoc Guidelines
+Writerside pages in `docs/` (`docs/mk.tree`); API docs via `./gradlew dokkaGenerate`.
 
-- Use `[ClassName]` / `[functionName]` references for cross-links.
-- Document view-vs-copy semantics explicitly.
-- See the `multik-kdoc` skill for the full KDoc style guide and audit workflow.
+Korro checks that the samples in `multik-core/src/commonTest/kotlin/samples/docs/` (delimited by
+`// SampleStart` / `// SampleEnd`) match the code blocks in `docs/topics/**/*.md` — edit both together.
 
-## Documentation
-
-- Writerside docs in `docs/` (config: `docs/mk.tree`).
-- API docs generated with Dokka: `./gradlew dokkaGenerate`.
-- Doc samples validated by the Korro plugin. Samples live in `multik-core/src/commonTest/kotlin/samples/docs/` and map
-  to `docs/topics/**/*.md`. Code blocks in sample files are delimited with `// SampleStart` and `// SampleEnd` comments.
-  Keep samples and markdown in sync.
-- See the `multik-docs` skill for Writerside page templates and conventions.
+Skills: `multik-kdoc` for KDoc style and audits, `multik-docs` for Writerside pages.

--- a/docs/topics/FAQ.md
+++ b/docs/topics/FAQ.md
@@ -103,16 +103,16 @@ It is **not** available on iOS, JS, or WASM.
 
 ## Common pitfalls
 
-### Reshaping a sliced array produces wrong data
+### Reshaping a sliced array returns a view, not a copy
 
-Slicing returns a **view** that shares the underlying data buffer with non-contiguous strides.
-`reshape` assumes contiguous memory, so it can produce incorrect results on views.
+`reshape` returns a **view** whenever the new shape can be addressed with strides over the existing
+data — which includes most slices. Writing to the result writes through to the original array.
 
-**Fix:** Call `.copy()` before reshaping:
+**Fix:** Call `.deepCopy()` first if you need a standalone array:
 
 ```kotlin
-val slice = array[0..2, 0..2]
-val reshaped = slice.copy().reshape(1, 4)  // correct
+val slice = array[0..1, 0..1]
+val reshaped = slice.deepCopy().reshape(1, 4)  // detached from `array`
 ```
 
 ### Mixing numeric types causes a runtime error

--- a/docs/topics/userGuide/copies-and-views.md
+++ b/docs/topics/userGuide/copies-and-views.md
@@ -83,7 +83,8 @@ Typical view-producing operations:
 
 * Indexing and slicing
 * `view(...)` and `slice(...)`
-* `transpose()` and `squeeze()`
+* `transpose()`
+* `squeeze()`, `unsqueeze()`, `expandDims(...)` and `expandNDims(...)`
 
 Operations that always allocate new storage:
 
@@ -91,8 +92,9 @@ Operations that always allocate new storage:
 * `flatten()`
 * `cat(...)` and `mk.stack(...)`
 
-Operations like `reshape()` and `unsqueeze()` return views when the array is contiguous;
-otherwise they materialize a copy to keep data consistent.
+`reshape()` returns a view whenever the new shape can be addressed with strides over the existing
+data. That covers contiguous arrays and most slices; it copies only when no such strides exist, as
+when a transposed array is reshaped across its axes.
 
 <seealso style="cards" title="Next steps">
 <category ref="user-guide">

--- a/docs/topics/userGuide/shape-manipulation.md
+++ b/docs/topics/userGuide/shape-manipulation.md
@@ -48,7 +48,9 @@ val c = b.reshape(3, 2)
 <!---END-->
 
 There is no `-1` dimension inference, so all dimensions must be specified explicitly.
-When possible, `reshape` returns a view; otherwise it may copy data to keep storage consistent.
+`reshape` returns a view whenever the new shape can be addressed with strides over the existing
+data — writing to the result then writes through to the original array. It copies only when no such
+strides exist, as when a transposed array is reshaped across its axes.
 
 ## Flatten
 
@@ -121,6 +123,12 @@ val row = v.unsqueeze(0) // shape (1, 3)
 <!---END-->
 
 You can also use `expandDims` / `expandNDims` as helpers for adding size-1 axes.
+
+Adding or removing a size-1 axis never moves data, so `squeeze`, `unsqueeze`, `expandDims`, and
+`expandNDims` always return a view sharing the original array's storage.
+
+Multik has no rank-0 arrays. When every axis has size 1 — `mk.zeros<Double>(1, 1)`, or any
+single-element array — `squeeze` keeps one axis and returns shape `(1)`.
 
 ## Concatenate and stack
 

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/random.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/api/random.kt
@@ -237,6 +237,8 @@ internal inline fun <T : Number> randData(
         from is Long && until is Long -> initMemoryView(size, dtype) { random.nextLong(from, until) }
         from is Float && until is Float -> initMemoryView(size, dtype) { random.nextDouble(f, u).toFloat() }
         from is Double && until is Double -> initMemoryView(size, dtype) { random.nextDouble(from, until) }
-        else -> throw UnsupportedOperationException()
+        else -> throw UnsupportedOperationException(
+            "Cannot draw random values in [$from, $until): the bounds must both be Int, Long, Float or Double."
+        )
     } as MemoryView<T>
 }

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/DataType.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/DataType.kt
@@ -70,7 +70,7 @@ public enum class DataType(public val nativeCode: Int, public val itemSize: Int,
                 6 -> DoubleDataType
                 7 -> ComplexFloatDataType
                 8 -> ComplexDoubleDataType
-                else -> throw IllegalStateException("One of the primitive types indexes was expected, got $i")
+                else -> throw IllegalArgumentException("Unknown native code $i: expected one of 1..8.")
             }
         }
 
@@ -78,8 +78,8 @@ public enum class DataType(public val nativeCode: Int, public val itemSize: Int,
          * Returns [DataType] by class of [element].
          */
         public inline fun <T> of(element: T): DataType {
-            element ?: throw IllegalStateException("Element is null cannot find type")
-            return dataTypeOf(element!!::class)
+            requireNotNull(element) { "Cannot determine the data type of a null element." }
+            return dataTypeOf(element::class)
         }
 
 

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/Internals.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/Internals.kt
@@ -107,6 +107,94 @@ internal fun computeStrides(shape: IntArray): IntArray = shape.copyOf().apply {
     }
 }
 
+/**
+ * Computes strides addressing [newShape] over the memory described by [shape] and [strides],
+ * without moving any element.
+ *
+ * A shape change can be expressed as a view whenever every group of old axes that the new shape
+ * merges is contiguous with respect to itself. Axes of size one are ignored, because a single
+ * element is reachable regardless of the stride assigned to its axis. This is the rule NumPy uses,
+ * so a copy is only needed when the requested layout genuinely cannot be strided over the existing
+ * buffer — for example when reshaping a transposed array to a shape that mixes its axes.
+ *
+ * @param shape the current shape.
+ * @param strides the current strides, in elements.
+ * @param newShape the requested shape; must describe the same number of elements as [shape].
+ * @return strides for [newShape] over the same memory, or `null` when the elements must be copied.
+ */
+internal fun reshapeStrides(shape: IntArray, strides: IntArray, newShape: IntArray): IntArray? {
+    if (newShape.isEmpty()) return IntArray(0)
+    // An empty array addresses no elements, so the packed strides of the new shape always fit.
+    if (shape.any { it == 0 }) return computeStrides(newShape)
+
+    // Drop axes of size one: their stride is never used and would otherwise break up
+    // groups of axes that are in fact contiguous.
+    var oldNd = 0
+    val oldShape = IntArray(shape.size)
+    val oldStrides = IntArray(shape.size)
+    for (axis in shape.indices) {
+        if (shape[axis] != 1) {
+            oldShape[oldNd] = shape[axis]
+            oldStrides[oldNd] = strides[axis]
+            oldNd++
+        }
+    }
+
+    val newStrides = IntArray(newShape.size)
+    // [oi, oj) and [ni, nj) delimit the groups of old and new axes holding the same elements.
+    var oi = 0
+    var oj = 1
+    var ni = 0
+    var nj = 1
+    while (ni < newShape.size && oi < oldNd) {
+        var newSize = newShape[ni]
+        var oldSize = oldShape[oi]
+        while (newSize != oldSize) {
+            if (newSize < oldSize) newSize *= newShape[nj++] else oldSize *= oldShape[oj++]
+        }
+
+        // Merging old axes is only possible when each one packs the next one exactly.
+        for (axis in oi until oj - 1) {
+            if (oldStrides[axis] != oldShape[axis + 1] * oldStrides[axis + 1]) return null
+        }
+
+        newStrides[nj - 1] = oldStrides[oj - 1]
+        for (axis in nj - 1 downTo ni + 1) {
+            newStrides[axis - 1] = newStrides[axis] * newShape[axis]
+        }
+
+        ni = nj++
+        oi = oj++
+    }
+
+    // Trailing axes of size one in the new shape; their stride is never used.
+    val lastStride = if (ni > 0) newStrides[ni - 1] else 1
+    for (axis in ni until newShape.size) newStrides[axis] = lastStride
+
+    return newStrides
+}
+
+/**
+ * Returns an array of [newShape] over this array's elements, sharing memory whenever possible.
+ *
+ * The result is a view whose [base][MultiArray.base] is the owner of this array's buffer when
+ * [reshapeStrides] can express [newShape] over the current layout, and a freshly packed copy
+ * otherwise.
+ *
+ * @param newShape the requested shape; callers must have checked that it holds [MultiArray.size] elements.
+ * @param newDim the [Dimension] matching [newShape].
+ */
+internal fun <T, D : Dimension, O : Dimension> MultiArray<T, D>.reshapeTo(
+    newShape: IntArray, newDim: O
+): NDArray<T, O> {
+    val newStrides = reshapeStrides(shape, strides, newShape)
+    return if (newStrides != null) {
+        NDArray(data, offset, newShape, newStrides, newDim, base ?: this)
+    } else {
+        NDArray(deepCopy().data, 0, newShape, computeStrides(newShape), newDim)
+    }
+}
+
 /** Converts this [Number] to the reified primitive type [T]. */
 @PublishedApi
 internal inline fun <reified T : Number> Number.toPrimitiveType(): T = when (T::class) {
@@ -116,7 +204,9 @@ internal inline fun <reified T : Number> Number.toPrimitiveType(): T = when (T::
     Long::class -> this.toLong()
     Float::class -> this.toFloat()
     Double::class -> this.toDouble()
-    else -> throw Exception("Type not defined.")
+    else -> throw IllegalArgumentException(
+        "Cannot convert $this to ${T::class.simpleName}: expected Byte, Short, Int, Long, Float or Double."
+    )
 } as T
 
 /**
@@ -124,7 +214,7 @@ internal inline fun <reified T : Number> Number.toPrimitiveType(): T = when (T::
  *
  * @param dtype the target [DataType] (must be a real numeric type, not complex).
  * @return this value converted to the target type.
- * @throws Exception if [dtype] is a complex type.
+ * @throws IllegalArgumentException if [dtype] is not a real numeric type.
  */
 @Suppress("UNCHECKED_CAST")
 public fun <T : Number> Number.toPrimitiveType(dtype: DataType): T = when (dtype.nativeCode) {
@@ -134,7 +224,9 @@ public fun <T : Number> Number.toPrimitiveType(dtype: DataType): T = when (dtype
     4 -> this.toLong()
     5 -> this.toFloat()
     6 -> this.toDouble()
-    else -> throw Exception("Type not defined.")
+    else -> throw IllegalArgumentException(
+        "Cannot convert $this to ${dtype.name}: expected a real numeric type, not a complex one."
+    )
 } as T
 
 /**

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MemoryView.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MemoryView.kt
@@ -125,21 +125,29 @@ public sealed class MemoryView<T> : ImmutableMemoryView<T> {
 
     public abstract override fun copyOf(): MemoryView<T>
 
-    public override fun getByteArray(): ByteArray = throw UnsupportedOperationException()
+    public override fun getByteArray(): ByteArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a ByteArray: it holds ${dtype.name} elements.")
 
-    public override fun getShortArray(): ShortArray = throw UnsupportedOperationException()
+    public override fun getShortArray(): ShortArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a ShortArray: it holds ${dtype.name} elements.")
 
-    public override fun getIntArray(): IntArray = throw UnsupportedOperationException()
+    public override fun getIntArray(): IntArray =
+        throw UnsupportedOperationException("Cannot read this buffer as an IntArray: it holds ${dtype.name} elements.")
 
-    public override fun getLongArray(): LongArray = throw UnsupportedOperationException()
+    public override fun getLongArray(): LongArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a LongArray: it holds ${dtype.name} elements.")
 
-    public override fun getFloatArray(): FloatArray = throw UnsupportedOperationException()
+    public override fun getFloatArray(): FloatArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a FloatArray: it holds ${dtype.name} elements.")
 
-    public override fun getDoubleArray(): DoubleArray = throw UnsupportedOperationException()
+    public override fun getDoubleArray(): DoubleArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a DoubleArray: it holds ${dtype.name} elements.")
 
-    public override fun getComplexFloatArray(): ComplexFloatArray = throw UnsupportedOperationException()
+    public override fun getComplexFloatArray(): ComplexFloatArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a ComplexFloatArray: it holds ${dtype.name} elements.")
 
-    public override fun getComplexDoubleArray(): ComplexDoubleArray = throw UnsupportedOperationException()
+    public override fun getComplexDoubleArray(): ComplexDoubleArray =
+        throw UnsupportedOperationException("Cannot read this buffer as a ComplexDoubleArray: it holds ${dtype.name} elements.")
 
     /** Adds each element of [other] to the corresponding element of this view in-place. */
     public operator fun plusAssign(other: MemoryView<T>) {

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MultiArrays.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/MultiArrays.kt
@@ -89,13 +89,16 @@ public interface MultiArray<T, D : Dimension> {
     // Reshape
 
     /**
-     * Returns a view of this array with the given 1D shape.
+     * Returns this array with the given 1D shape.
      *
-     * The new shape must have the same total [size]. Returns a view when the array is [consistent];
-     * otherwise performs a deep copy first.
+     * The new shape must have the same total [size]. The result is a view sharing this array's
+     * [data] whenever the requested shape can be addressed with strides over the current layout.
+     * That is always so for a [consistent] array and usually so for a slice; only a layout that
+     * cannot be strided — reshaping a transposed array across its axes, for instance — copies the
+     * elements into a new buffer. Writing to a view writes through to the original array.
      *
      * @param dim1 size of the single dimension (must equal [size]).
-     * @return a 1D view or copy with shape `[dim1]`.
+     * @return a 1D view with shape `[dim1]`, or a copy when the new shape cannot be strided over [data].
      * @throws IllegalArgumentException if [dim1] is not positive or does not equal [size].
      */
     public fun reshape(dim1: Int): MultiArray<T, D1>
@@ -105,7 +108,7 @@ public interface MultiArray<T, D : Dimension> {
      *
      * @param dim1 size of the first dimension.
      * @param dim2 size of the second dimension.
-     * @return a 2D view or copy with shape `[dim1, dim2]`.
+     * @return a 2D view with shape `[dim1, dim2]`, or a copy when it cannot be strided over [data].
      * @throws IllegalArgumentException if the product of dimensions does not equal [size].
      * @see [reshape]
      */
@@ -117,7 +120,7 @@ public interface MultiArray<T, D : Dimension> {
      * @param dim1 size of the first dimension.
      * @param dim2 size of the second dimension.
      * @param dim3 size of the third dimension.
-     * @return a 3D view or copy with shape `[dim1, dim2, dim3]`.
+     * @return a 3D view with shape `[dim1, dim2, dim3]`, or a copy when it cannot be strided over [data].
      * @throws IllegalArgumentException if the product of dimensions does not equal [size].
      * @see [reshape]
      */
@@ -130,7 +133,7 @@ public interface MultiArray<T, D : Dimension> {
      * @param dim2 size of the second dimension.
      * @param dim3 size of the third dimension.
      * @param dim4 size of the fourth dimension.
-     * @return a 4D view or copy with shape `[dim1, dim2, dim3, dim4]`.
+     * @return a 4D view with shape `[dim1, dim2, dim3, dim4]`, or a copy when it cannot be strided over [data].
      * @throws IllegalArgumentException if the product of dimensions does not equal [size].
      * @see [reshape]
      */
@@ -144,7 +147,7 @@ public interface MultiArray<T, D : Dimension> {
      * @param dim3 size of the third dimension.
      * @param dim4 size of the fourth dimension.
      * @param dims sizes of remaining dimensions.
-     * @return an N-dimensional view or copy.
+     * @return an N-dimensional view, or a copy when the new shape cannot be strided over [data].
      * @throws IllegalArgumentException if the product of all dimensions does not equal [size].
      * @see [reshape]
      */
@@ -170,9 +173,15 @@ public interface MultiArray<T, D : Dimension> {
      * When called with no arguments, removes all axes whose size is 1.
      * When called with specific [axes], removes only those axes (they must have size 1).
      *
-     * @param axes optional indices of axes to squeeze. Each must have `shape[axis] == 1`.
-     * @return a view with reduced dimensionality.
-     * @throws IllegalArgumentException if any specified axis does not have size 1.
+     * Dropping a size-one axis never moves data, so the result always shares this array's [data].
+     *
+     * Multik has no rank-0 arrays. When every axis has size 1 — `mk.zeros<Double>(1, 1)`, or any
+     * single-element array — one axis is kept and the result has shape `[1]`, the same array
+     * `squeeze(0)` already returns today.
+     *
+     * @param axes optional indices of axes to squeeze. Each must be in `0 until dim.d` and have `shape[axis] == 1`.
+     * @return a view with reduced dimensionality, sharing this array's data.
+     * @throws IllegalArgumentException if any specified axis is out of bounds or does not have size 1.
      * @see [unsqueeze]
      */
     public fun squeeze(vararg axes: Int): MultiArray<T, DN>
@@ -181,8 +190,12 @@ public interface MultiArray<T, D : Dimension> {
     /**
      * Returns a view with a size-one dimension inserted at each of the specified [axes].
      *
-     * @param axes positions at which to insert new dimensions of size 1.
-     * @return a view with increased dimensionality.
+     * Inserting a size-one axis never moves data, so the result always shares this array's [data].
+     *
+     * @param axes positions at which to insert new dimensions of size 1. Each must be unique and in
+     *   `0 until (dim.d + axes.size)`, i.e. addressed in the resulting array's coordinates.
+     * @return a view with increased dimensionality, sharing this array's data.
+     * @throws IllegalArgumentException if [axes] contains duplicates or an out-of-bounds position.
      * @see [squeeze]
      */
     public fun unsqueeze(vararg axes: Int): MultiArray<T, DN>

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/NDArray.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/NDArray.kt
@@ -131,22 +131,12 @@ public class NDArray<T, D : Dimension> constructor(
         return D1Array(data, 0, intArrayOf(size), dim = D1)
     }
 
-    // TODO(strides? : view.reshape().reshape()?)
     override fun reshape(dim1: Int): D1Array<T> {
         // todo negative shape?
         requirePositiveShape(dim1)
         require(dim1 == size) { "Cannot reshape array of size $size into a new shape ($dim1)" }
 
-        // TODO(get rid of copying)
-        val newData = if (consistent) this.data else this.deepCopy().data
-        val newBase = if (consistent) this.base ?: this else null
-        val newOffset = if (consistent) this.offset else 0
-
-        return if (this.dim.d == 1 && this.shape.first() == dim1) {
-            this as D1Array<T>
-        } else {
-            D1Array(newData, newOffset, intArrayOf(dim1), dim = D1, base = newBase)
-        }
+        return reshapeTo(intArrayOf(dim1), D1)
     }
 
     override fun reshape(dim1: Int, dim2: Int): D2Array<T> {
@@ -154,16 +144,7 @@ public class NDArray<T, D : Dimension> constructor(
         newShape.forEach { requirePositiveShape(it) }
         require(dim1 * dim2 == size) { "Cannot reshape array of size $size into a new shape ($dim1, $dim2)" }
 
-        // TODO(get rid of copying)
-        val newData = if (consistent) this.data else this.deepCopy().data
-        val newBase = if (consistent) this.base ?: this else null
-        val newOffset = if (consistent) this.offset else 0
-
-        return if (this.shape.contentEquals(newShape)) {
-            this as D2Array<T>
-        } else {
-            D2Array(newData, newOffset, newShape, dim = D2, base = newBase)
-        }
+        return reshapeTo(newShape, D2)
     }
 
     override fun reshape(dim1: Int, dim2: Int, dim3: Int): D3Array<T> {
@@ -171,16 +152,7 @@ public class NDArray<T, D : Dimension> constructor(
         newShape.forEach { requirePositiveShape(it) }
         require(dim1 * dim2 * dim3 == size) { "Cannot reshape array of size $size into a new shape ($dim1, $dim2, $dim3)" }
 
-        // TODO(get rid of copying)
-        val newData = if (consistent) this.data else this.deepCopy().data
-        val newBase = if (consistent) base ?: this else null
-        val newOffset = if (consistent) this.offset else 0
-
-        return if (this.shape.contentEquals(newShape)) {
-            this as D3Array<T>
-        } else {
-            D3Array(newData, newOffset, newShape, dim = D3, base = newBase)
-        }
+        return reshapeTo(newShape, D3)
     }
 
     override fun reshape(dim1: Int, dim2: Int, dim3: Int, dim4: Int): D4Array<T> {
@@ -188,16 +160,7 @@ public class NDArray<T, D : Dimension> constructor(
         newShape.forEach { requirePositiveShape(it) }
         require(dim1 * dim2 * dim3 * dim4 == size) { "Cannot reshape array of size $size into a new shape ($dim1, $dim2, $dim3, $dim4)" }
 
-        // TODO(get rid of copying)
-        val newData = if (consistent) this.data else this.deepCopy().data
-        val newBase = if (consistent) this.base ?: this else null
-        val newOffset = if (consistent) this.offset else 0
-
-        return if (this.shape.contentEquals(newShape)) {
-            this as D4Array<T>
-        } else {
-            D4Array(newData, newOffset, newShape, dim = D4, base = newBase)
-        }
+        return reshapeTo(newShape, D4)
     }
 
     override fun reshape(dim1: Int, dim2: Int, dim3: Int, dim4: Int, vararg dims: Int): NDArray<T, DN> {
@@ -207,16 +170,7 @@ public class NDArray<T, D : Dimension> constructor(
             "Cannot reshape array of size $size into a new shape ${newShape.joinToString(prefix = "(", postfix = ")")}"
         }
 
-        // TODO(get rid of copying)
-        val newData = if (consistent) this.data else this.deepCopy().data
-        val newBase = if (consistent) this.base ?: this else null
-        val newOffset = if (consistent) this.offset else 0
-
-        return if (this.shape.contentEquals(newShape)) {
-            this as NDArray<T, DN>
-        } else {
-            NDArray(newData, newOffset, newShape, dim = DN(newShape.size), base = newBase)
-        }
+        return reshapeTo(newShape, DN(newShape.size))
     }
 
     override fun transpose(vararg axes: Int): NDArray<T, D> {
@@ -244,24 +198,37 @@ public class NDArray<T, D : Dimension> constructor(
         val cutAxes = if (axes.isEmpty()) {
             shape.withIndex().filter { it.value == 1 }.map { it.index }
         } else {
-            require(axes.all { shape[it] == 1 }) { "Cannot select an axis to squeeze out which has size not equal to one." }
+            for (axis in axes) {
+                require(axis in shape.indices) { "Axis $axis is out of bounds for an array of dimension ${dim.d}." }
+                require(shape[axis] == 1) {
+                    "Cannot squeeze axis $axis of shape ${shape.joinToString(prefix = "(", postfix = ")")}: " +
+                        "its size is ${shape[axis]}, not 1."
+                }
+            }
             axes.toList()
         }
-        val newShape = this.shape.sliceArray(this.shape.indices - cutAxes)
-        return NDArray(this.data, this.offset, newShape, dim = DN(newShape.size), base = base ?: this)
+        val squeezed = this.shape.sliceArray(this.shape.indices - cutAxes)
+        // no rank-0 arrays, so keep one size-one axis when every axis would be dropped.
+        val newShape = if (squeezed.isEmpty()) intArrayOf(1) else squeezed
+        return reshapeTo(newShape, DN(newShape.size))
     }
 
     override fun unsqueeze(vararg axes: Int): NDArray<T, DN> {
+        val newRank = dim.d + axes.size
+        for (axis in axes) {
+            require(axis in 0 until newRank) {
+                "Axis $axis is out of bounds for the resulting array of dimension $newRank."
+            }
+        }
+        require(axes.toSet().size == axes.size) {
+            "The specified axes must be unique, but got ${axes.joinToString(prefix = "(", postfix = ")")}."
+        }
+
         val newShape = shape.toMutableList()
         for (axis in axes.sorted()) {
             newShape.add(axis, 1)
         }
-        // TODO(get rid of copying)
-        val newData = if (consistent) this.data else this.deepCopy().data
-        val newBase = if (consistent) this.base ?: this else null
-        val newOffset = if (consistent) this.offset else 0
-
-        return NDArray(newData, newOffset, newShape.toIntArray(), dim = DN(newShape.size), base = newBase)
+        return reshapeTo(newShape.toIntArray(), DN(newShape.size))
     }
 
     override infix fun cat(other: MultiArray<T, D>): NDArray<T, D> =
@@ -337,10 +304,11 @@ public class NDArray<T, D : Dimension> constructor(
      * creates a new view with [DN] as the dimension type.
      *
      * @return this array typed as `NDArray<T, DN>`.
-     * @throws Exception if the array dimension is undefined (-1).
+     * @throws IllegalStateException if the array's dimension is undefined (-1), which indicates a
+     *   malformed array rather than a caller error.
      */
     public fun asDNArray(): NDArray<T, DN> {
-        if (this.dim.d == -1) throw Exception("Array dimension is undefined")
+        check(this.dim.d != -1) { "Array dimension is undefined: the array was built with DN(-1)." }
         if (this.dim.d > 4) return this as NDArray<T, DN>
 
         return NDArray(this.data, this.offset, this.shape, this.strides, DN(this.dim.d), base = base ?: this)

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/Slice.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/Slice.kt
@@ -106,13 +106,13 @@ public fun IntRange.toSlice(): Slice = Slice(this.first, this.last, 1)
  *
  * Supports [Slice], [IntRange], or any other [ClosedRange]<[Int]>.
  *
- * @throws IllegalStateException if the range type is not [Slice] or [IntRange].
+ * @throws IllegalArgumentException if the range type is not [Slice] or [IntRange].
  */
 public fun ClosedRange<Int>.toSlice(): Slice =
     when(this) {
         is Slice -> this
         is IntRange -> this.toSlice()
-        else -> throw IllegalStateException("${this::class} not supported, please use Slice or IntRange.")
+        else -> throw IllegalArgumentException("${this::class} is not supported, please use Slice or IntRange.")
     }
 
 /**

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/IteratingNDArray.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/IteratingNDArray.kt
@@ -92,7 +92,7 @@ public infix fun <T : Number, D : Dimension> MultiArray<T, D>.and(other: MultiAr
             DataType.LongDataType -> (lIter.next().toLong() and rIter.next().toLong()).toInt()
             DataType.ShortDataType -> (lIter.next().toShort() and rIter.next().toShort()).toInt()
             DataType.ByteDataType -> (lIter.next().toByte() and rIter.next().toByte()).toInt()
-            else -> throw Exception("")
+            else -> throw UnsupportedOperationException("`and` is not supported for ${dtype.name}.")
         }
     }
     return ret
@@ -141,7 +141,7 @@ public infix fun <T : Number, D : Dimension> MultiArray<T, D>.or(other: MultiArr
             DataType.LongDataType -> (lIter.next().toLong() or rIter.next().toLong()).toInt()
             DataType.ShortDataType -> (lIter.next().toShort() or rIter.next().toShort()).toInt()
             DataType.ByteDataType -> (lIter.next().toByte() or rIter.next().toByte()).toInt()
-            else -> throw Exception("")
+            else -> throw UnsupportedOperationException("`or` is not supported for ${dtype.name}.")
         }
     }
     return ret
@@ -869,7 +869,7 @@ public fun <T: Number, D : Dimension> MultiArray<T, D>.minimum(other: MultiArray
         DataType.LongDataType -> (ret as NDArray<Long, D>).commonAssignOp(other.iterator() as Iterator<Long>) { a, b -> min(a, b) }
         DataType.ShortDataType -> (ret as NDArray<Short, D>).commonAssignOp(other.iterator() as Iterator<Short>) { a, b -> (minOf(a, b)) }
         DataType.ByteDataType -> (ret as NDArray<Byte, D>).commonAssignOp(other.iterator() as Iterator<Byte>) { a, b -> (minOf(a, b)) }
-        else -> throw UnsupportedOperationException("The operations is not supported for the $dtype")
+        else -> throw UnsupportedOperationException("`minimum` is not supported for ${dtype.name}.")
     }
     return ret
 }
@@ -887,7 +887,7 @@ public fun <T: Number, D : Dimension> MultiArray<T, D>.maximum(other: MultiArray
         DataType.LongDataType -> (ret as NDArray<Long, D>).commonAssignOp(other.iterator() as Iterator<Long>) { a, b -> max(a, b) }
         DataType.ShortDataType -> (ret as NDArray<Short, D>).commonAssignOp(other.iterator() as Iterator<Short>) { a, b ->(maxOf (a, b)) }
         DataType.ByteDataType -> (ret as NDArray<Byte, D>).commonAssignOp(other.iterator() as Iterator<Byte>) { a, b ->(maxOf (a, b)) }
-        else -> throw UnsupportedOperationException("The operations is not supported for the $dtype")
+        else -> throw UnsupportedOperationException("`maximum` is not supported for ${dtype.name}.")
     }
     return ret
 }
@@ -1302,7 +1302,7 @@ public fun <T : Number, D : Dimension> MultiArray<T, D>.sorted(): NDArray<T, D> 
         DataType.FloatDataType -> ret.data.getFloatArray().sort()
         DataType.DoubleDataType -> ret.data.getDoubleArray().sort()
         DataType.ComplexFloatDataType, DataType.ComplexDoubleDataType ->
-            throw Exception("Complex numbers cannot be sorted.")
+            throw UnsupportedOperationException("Cannot sort an array of ${dtype.name}: complex numbers have no natural order.")
     }
     return ret
 }
@@ -1851,7 +1851,7 @@ public fun <T, O : Any, D : Dimension> MultiArray<T, D>.toType(
                 }
             }
         }
-        else -> throw Exception()
+        else -> throw UnsupportedOperationException("Cannot convert an array of ${this.dtype.name} to ${dtype.name}.")
     }
     return NDArray(view, offset, this.shape.copyOf(), strides, this.dim)
 }

--- a/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/Transformation.kt
+++ b/multik-core/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/ndarray/operations/Transformation.kt
@@ -4,11 +4,8 @@ import org.jetbrains.kotlinx.multik.api.Multik
 import org.jetbrains.kotlinx.multik.ndarray.data.D1
 import org.jetbrains.kotlinx.multik.ndarray.data.D1Array
 import org.jetbrains.kotlinx.multik.ndarray.data.D2
-import org.jetbrains.kotlinx.multik.ndarray.data.D2Array
 import org.jetbrains.kotlinx.multik.ndarray.data.D3
-import org.jetbrains.kotlinx.multik.ndarray.data.D3Array
 import org.jetbrains.kotlinx.multik.ndarray.data.D4
-import org.jetbrains.kotlinx.multik.ndarray.data.D4Array
 import org.jetbrains.kotlinx.multik.ndarray.data.DN
 import org.jetbrains.kotlinx.multik.ndarray.data.DataType
 import org.jetbrains.kotlinx.multik.ndarray.data.Dimension
@@ -19,6 +16,7 @@ import org.jetbrains.kotlinx.multik.ndarray.data.actualAxis
 import org.jetbrains.kotlinx.multik.ndarray.data.dimensionOf
 import org.jetbrains.kotlinx.multik.ndarray.data.get
 import org.jetbrains.kotlinx.multik.ndarray.data.initMemoryView
+import org.jetbrains.kotlinx.multik.ndarray.data.reshapeTo
 import kotlin.jvm.JvmName
 
 /**
@@ -346,7 +344,9 @@ internal fun <T, D : Dimension, O : Dimension> concatenate(
                     }
                 }
 
-                else -> throw UnsupportedOperationException()
+                else -> throw UnsupportedOperationException(
+                    "Concatenation is not supported for arrays of dimension ${dest.dim.d}."
+                )
             }
         }
     }
@@ -383,53 +383,50 @@ public fun <T, D : Dimension> MultiArray<T, D>.clip(min: T, max: T): NDArray<T, 
 /**
  * Inserts a size-1 axis at position [axis], promoting a 1D array to 2D.
  *
- * Returns a view when the array is [consistent][MultiArray.consistent], otherwise copies.
+ * Always returns a view sharing this array's data; no elements are copied.
  *
  * @param axis position where the new axis is inserted.
- * @return a 2D view (or copy) with a size-1 dimension at [axis].
+ * @return a 2D view with a size-1 dimension at [axis].
  * @see [unsqueeze]
  */
 @JvmName("expandDimsD1")
-public fun <T> MultiArray<T, D1>.expandDims(axis: Int): MultiArray<T, D2> {
-    val newShape = shape.toMutableList().apply { add(axis, 1) }.toIntArray()
-    // TODO(get rid of copying)
-    val newData = if (consistent) this.data else this.deepCopy().data
-    val newBase = if (consistent) this.base ?: this else null
-    val newOffset = if (consistent) this.offset else 0
-    return D2Array(newData, newOffset, newShape, dim = D2, base = newBase)
-}
+public fun <T> MultiArray<T, D1>.expandDims(axis: Int): MultiArray<T, D2> =
+    reshapeTo(shape.toMutableList().apply { add(axis, 1) }.toIntArray(), D2)
 
-/** Inserts a size-1 axis at position [axis], promoting a 2D array to 3D. */
+/**
+ * Inserts a size-1 axis at position [axis], promoting a 2D array to 3D.
+ *
+ * Always returns a view sharing this array's data; no elements are copied.
+ */
 @JvmName("expandDimsD2")
-public fun <T> MultiArray<T, D2>.expandDims(axis: Int): MultiArray<T, D3> {
-    val newShape = shape.toMutableList().apply { add(axis, 1) }.toIntArray()
-    // TODO(get rid of copying)
-    val newData = if (consistent) this.data else this.deepCopy().data
-    val newBase = if (consistent) this.base ?: this else null
-    val newOffset = if (consistent) this.offset else 0
-    return D3Array(newData, newOffset, newShape, dim = D3, base = newBase)
-}
+public fun <T> MultiArray<T, D2>.expandDims(axis: Int): MultiArray<T, D3> =
+    reshapeTo(shape.toMutableList().apply { add(axis, 1) }.toIntArray(), D3)
 
-/** Inserts a size-1 axis at position [axis], promoting a 3D array to 4D. */
+/**
+ * Inserts a size-1 axis at position [axis], promoting a 3D array to 4D.
+ *
+ * Always returns a view sharing this array's data; no elements are copied.
+ */
 @JvmName("expandDimsD3")
-public fun <T> MultiArray<T, D3>.expandDims(axis: Int): MultiArray<T, D4> {
-    val newShape = shape.toMutableList().apply { add(axis, 1) }.toIntArray()
-    // TODO(get rid of copying)
-    val newData = if (consistent) this.data else this.deepCopy().data
-    val newBase = if (consistent) this.base ?: this else null
-    val newOffset = if (consistent) this.offset else 0
-    return D4Array(newData, newOffset, newShape, dim = D4, base = newBase)
-}
+public fun <T> MultiArray<T, D3>.expandDims(axis: Int): MultiArray<T, D4> =
+    reshapeTo(shape.toMutableList().apply { add(axis, 1) }.toIntArray(), D4)
 
-/** Inserts a size-1 axis at position [axis], promoting a 4D array to N-dimensional. */
+/**
+ * Inserts a size-1 axis at position [axis], promoting a 4D array to N-dimensional.
+ *
+ * Always returns a view sharing this array's data; no elements are copied.
+ */
 @JvmName("expandDimsD4")
-public fun <T> MultiArray<T, D4>.expandDims(axis: Int): MultiArray<T, DN> = this.unsqueeze()
+public fun <T> MultiArray<T, D4>.expandDims(axis: Int): MultiArray<T, DN> = this.unsqueeze(axis)
 
 /**
  * Inserts size-1 axes at the given positions, returning an N-dimensional array.
+ *
+ * Always returns a view sharing this array's data; no elements are copied.
  *
  * @param axes positions where new axes are inserted.
  * @see [unsqueeze]
  */
 @JvmName("expandDimsDN")
-public fun <T, D : Dimension> MultiArray<T, D>.expandNDims(vararg axes: Int): MultiArray<T, DN> = this.unsqueeze()
+public fun <T, D : Dimension> MultiArray<T, D>.expandNDims(vararg axes: Int): MultiArray<T, DN> =
+    this.unsqueeze(*axes)

--- a/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/ErrorHandlingTest.kt
+++ b/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/ErrorHandlingTest.kt
@@ -1,0 +1,69 @@
+package org.jetbrains.kotlinx.multik.ndarray.data
+
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.ndarrayOf
+import org.jetbrains.kotlinx.multik.api.zeros
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
+
+/**
+ * Pins the error-handling policy: an invalid argument is an [IllegalArgumentException], a missing
+ * implementation is an [UnsupportedOperationException], and every message names the value that
+ * caused the failure so the caller can act on it without reading the source.
+ */
+class ErrorHandlingTest {
+
+    @Test
+    fun testInvalidShapeArgumentsAreIllegalArgument() {
+        val a = mk.ndarrayOf(1, 2, 3, 4, 5, 6)
+
+        assertContains(assertFailsWith<IllegalArgumentException> { a.reshape(4, 2) }.message.orEmpty(), "(4, 2)")
+        assertContains(assertFailsWith<IllegalArgumentException> { a.reshape(0) }.message.orEmpty(), "0")
+        assertFailsWith<IllegalArgumentException> { a.reshape(2, 3, 4) }
+    }
+
+    @Test
+    fun testInvalidAxisArgumentsAreIllegalArgument() {
+        val a = mk.zeros<Double>(1, 3)
+
+        assertContains(assertFailsWith<IllegalArgumentException> { a.squeeze(1) }.message.orEmpty(), "(1, 3)")
+        assertFailsWith<IllegalArgumentException> { a.squeeze(7) }
+        assertFailsWith<IllegalArgumentException> { a.unsqueeze(9) }
+        assertFailsWith<IllegalArgumentException> { a.transpose(0, 0) }
+    }
+
+    @Test
+    fun testUnknownDataTypeCodeIsIllegalArgument() {
+        assertContains(assertFailsWith<IllegalArgumentException> { DataType.of(0) }.message.orEmpty(), "0")
+        assertContains(assertFailsWith<IllegalArgumentException> { DataType.of(9) }.message.orEmpty(), "9")
+        assertFailsWith<IllegalArgumentException> { DataType.of<String?>(null) }
+    }
+
+    @Test
+    fun testConvertingToANonNumericDataTypeIsIllegalArgument() {
+        val e = assertFailsWith<IllegalArgumentException> {
+            (5 as Number).toPrimitiveType<Int>(DataType.ComplexFloatDataType)
+        }
+        assertContains(e.message.orEmpty(), "ComplexFloatDataType")
+    }
+
+    @Test
+    fun testReadingAMemoryViewAsTheWrongArrayTypeIsUnsupported() {
+        val data = mk.ndarrayOf(1, 2, 3).data
+
+        val e = assertFailsWith<UnsupportedOperationException> { data.getDoubleArray() }
+        assertContains(e.message.orEmpty(), "IntDataType")
+        assertFailsWith<UnsupportedOperationException> { data.getComplexFloatArray() }
+        assertFailsWith<UnsupportedOperationException> { data.getByteArray() }
+    }
+
+    @Test
+    fun testUnsupportedRangeTypeIsIllegalArgument() {
+        val range = object : ClosedRange<Int> {
+            override val start: Int get() = 0
+            override val endInclusive: Int get() = 2
+        }
+        assertFailsWith<IllegalArgumentException> { range.toSlice() }
+    }
+}

--- a/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/ReshapeTest.kt
+++ b/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/ReshapeTest.kt
@@ -1,0 +1,306 @@
+package org.jetbrains.kotlinx.multik.ndarray.data
+
+import org.jetbrains.kotlinx.multik.api.d2array
+import org.jetbrains.kotlinx.multik.api.d3array
+import org.jetbrains.kotlinx.multik.api.d4array
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.ndarray
+import org.jetbrains.kotlinx.multik.api.ndarrayOf
+import org.jetbrains.kotlinx.multik.api.zeros
+import org.jetbrains.kotlinx.multik.ndarray.operations.expandDims
+import org.jetbrains.kotlinx.multik.ndarray.operations.expandNDims
+import org.jetbrains.kotlinx.multik.ndarray.operations.toList
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * Shape changes must never move data unless the requested layout genuinely cannot be strided over
+ * the existing buffer, and must always produce the same elements in the same order either way.
+ */
+class ReshapeTest {
+
+    // Views
+
+    @Test
+    fun testReshapeOfContiguousArrayIsAView() {
+        val a = mk.d2array(2, 3) { it }
+        val b = a.reshape(3, 2)
+
+        assertSame(a.data, b.data)
+        assertSame(a, b.base)
+        assertContentEquals(intArrayOf(2, 1), b.strides)
+        assertEquals(mk.ndarray(mk[mk[0, 1], mk[2, 3], mk[4, 5]]), b)
+    }
+
+    @Test
+    fun testReshapeOfSliceIsAViewKeepingOffset() {
+        val a = mk.d2array(4, 4) { it }
+        val slice = a[1 until 3] as NDArray<Int, D2>
+        val b = slice.reshape(2, 2, 2)
+
+        assertSame(a.data, b.data)
+        assertSame(a, b.base)
+        assertEquals(slice.offset, b.offset)
+        assertEquals(slice.toList(), b.toList())
+    }
+
+    @Test
+    fun testReshapeWritesThroughToTheSource() {
+        val a = mk.d2array(2, 3) { it }
+        val b = a.reshape(6) as D1Array<Int>
+        b[0] = 42
+
+        assertEquals(42, a[0, 0])
+    }
+
+    @Test
+    fun testChainedReshapeOfAViewStaysAView() {
+        val a = mk.d3array(2, 3, 4) { it }
+        val slice = a[0 until 1] as NDArray<Int, D3>
+        val b = slice.reshape(12).reshape(3, 4).reshape(2, 2, 3)
+
+        assertSame(a.data, b.data)
+        assertEquals(slice.toList(), b.toList())
+    }
+
+    @Test
+    fun testReshapeOfSteppedSliceIsAView() {
+        // A stepped 1D slice is not `consistent`, but (3, 2) is still reachable with strides
+        // (2 * step, step) over the same buffer.
+        val a = mk.ndarrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+        val stepped = a[sl.bounds..2] as NDArray<Int, D1>
+        val b = stepped.reshape(3, 2)
+
+        assertSame(a.data, b.data)
+        assertContentEquals(intArrayOf(4, 2), b.strides)
+        assertEquals(stepped.toList(), b.toList())
+        assertEquals(listOf(0, 2, 4, 6, 8, 10), b.toList())
+    }
+
+    @Test
+    fun testReshapeOfTransposedArrayIsAViewWhenAxesAreNotMixed() {
+        // (3, 2) -> (3, 2, 1) only adds a size-one axis, which every layout can express.
+        val t = mk.d2array(2, 3) { it }.transpose()
+        val b = t.reshape(3, 2, 1)
+
+        assertSame(t.data, b.data)
+        assertEquals(t.toList(), b.toList())
+    }
+
+    // Copies
+
+    @Test
+    fun testReshapeOfTransposedArrayCopiesWhenAxesAreMixed() {
+        val a = mk.d2array(2, 3) { it }
+        val t = a.transpose()
+        val b = t.reshape(6) as D1Array<Int>
+
+        assertNotSame(a.data, b.data)
+        assertNull(b.base)
+        assertEquals(listOf(0, 3, 1, 4, 2, 5), b.toList())
+
+        b[0] = 42
+        assertEquals(0, a[0, 0])
+    }
+
+    @Test
+    fun testReshapeOfNonContiguousSliceCopiesWhenAxesAreMerged() {
+        val a = mk.d2array(3, 4) { it }
+        val slice = a[0 until 3, 0 until 2] as NDArray<Int, D2>
+
+        // Rows are 2 elements wide but 4 apart in the buffer, so merging them cannot be strided.
+        val merged = slice.reshape(6) as D1Array<Int>
+        assertNotSame(a.data, merged.data)
+        assertNull(merged.base)
+        assertEquals(listOf(0, 1, 4, 5, 8, 9), merged.toList())
+
+        // Appending size-one axes merges nothing, so the same slice stays a view.
+        val padded = slice.reshape(3, 2, 1, 1)
+        assertSame(a.data, padded.data)
+        assertEquals(slice.toList(), padded.toList())
+    }
+
+    // squeeze / unsqueeze
+
+    @Test
+    fun testSqueezeOfStridedSubArrayKeepsElements() {
+        // Regression: squeeze used to recompute packed strides and silently read the wrong elements.
+        val a = mk.d3array(2, 3, 4) { it }
+        val slice = a[0 until 2, 1 until 2, 0 until 4] as NDArray<Int, D3>
+        val squeezed = slice.squeeze()
+
+        assertContentEquals(intArrayOf(2, 4), squeezed.shape)
+        assertEquals(listOf(4, 5, 6, 7, 16, 17, 18, 19), squeezed.toList())
+        assertSame(a.data, squeezed.data)
+    }
+
+    @Test
+    fun testSqueezeOfSelectedAxisKeepsElements() {
+        val a = mk.d4array(2, 1, 1, 3) { it }
+        val transposed = a.transpose(0, 2, 1, 3)
+        val squeezed = transposed.squeeze(1)
+
+        assertContentEquals(intArrayOf(2, 1, 3), squeezed.shape)
+        assertEquals(transposed.toList(), squeezed.toList())
+    }
+
+    @Test
+    fun testUnsqueezeOfStridedSubArrayIsAView() {
+        val a = mk.d2array(2, 3) { it }
+        val slice = a[0 until 2, 1 until 3] as NDArray<Int, D2>
+
+        for (axis in 0..2) {
+            val unsqueezed = slice.unsqueeze(axis)
+            assertSame(a.data, unsqueezed.data, "unsqueeze($axis) copied")
+            assertEquals(slice.toList(), unsqueezed.toList(), "unsqueeze($axis) changed elements")
+            assertEquals(1, unsqueezed.shape[axis])
+        }
+    }
+
+    @Test
+    fun testSqueezeUnsqueezeRoundTrip() {
+        val a = mk.d3array(2, 3, 4) { it }
+        val slice = a[0 until 2, 0 until 2, 1 until 3] as NDArray<Int, D3>
+        val roundTrip = slice.unsqueeze(0, 2).squeeze(0, 2)
+
+        assertContentEquals(slice.shape, roundTrip.shape)
+        assertEquals(slice.toList(), roundTrip.toList())
+    }
+
+    @Test
+    fun testSqueezeKeepsOneAxisWhenEveryAxisWouldBeDropped() {
+        // Multik has no rank-0 arrays, so squeezing everything leaves shape [1] instead of throwing.
+        assertContentEquals(intArrayOf(1), mk.zeros<Double>(1, 1).squeeze().shape)
+        assertContentEquals(intArrayOf(1), mk.zeros<Double>(1, 1, 1).squeeze().shape)
+        assertContentEquals(intArrayOf(1), mk.ndarrayOf(5).squeeze().shape)
+        // Which is exactly what naming the axes explicitly already returned.
+        assertContentEquals(intArrayOf(1), mk.zeros<Double>(1, 1).squeeze(0).shape)
+        assertContentEquals(intArrayOf(1), mk.zeros<Double>(1, 1).squeeze(0, 1).shape)
+
+        val a = mk.zeros<Double>(1, 1)
+        assertSame(a.data, a.squeeze().data)
+        assertEquals(listOf(0.0), a.squeeze().toList())
+    }
+
+    @Test
+    fun testSqueezeRejectsInvalidAxes() {
+        val a = mk.zeros<Double>(1, 3)
+        assertFailsWith<IllegalArgumentException> { a.squeeze(1) }.let {
+            assertContains(it.message.orEmpty(), "not 1")
+        }
+        assertFailsWith<IllegalArgumentException> { a.squeeze(7) }
+        assertFailsWith<IllegalArgumentException> { a.squeeze(-1) }
+    }
+
+    @Test
+    fun testUnsqueezeRejectsInvalidAxes() {
+        val a = mk.ndarrayOf(1, 2, 3)
+        // Axes address the resulting array, so 2 is valid for a single insertion but 5 is not.
+        assertContentEquals(intArrayOf(3, 1), a.unsqueeze(1).shape)
+        assertFailsWith<IllegalArgumentException> { a.unsqueeze(5) }
+        assertFailsWith<IllegalArgumentException> { a.unsqueeze(-1) }
+        assertFailsWith<IllegalArgumentException> { a.unsqueeze(1, 1) }
+    }
+
+    // expandDims
+
+    @Test
+    fun testExpandDimsInsertsAxisAtTheGivenPosition() {
+        val d1 = mk.ndarrayOf(1, 2, 3)
+        assertContentEquals(intArrayOf(3, 1), d1.expandDims(1).shape)
+        assertContentEquals(intArrayOf(1, 3), d1.expandDims(0).shape)
+
+        val d2 = mk.d2array(2, 3) { it }
+        assertContentEquals(intArrayOf(2, 1, 3), d2.expandDims(1).shape)
+
+        val d3 = mk.d3array(2, 3, 4) { it }
+        assertContentEquals(intArrayOf(2, 3, 1, 4), d3.expandDims(2).shape)
+
+        val d4 = mk.d4array(2, 3, 4, 5) { it }
+        assertContentEquals(intArrayOf(2, 3, 1, 4, 5), d4.expandDims(2).shape)
+
+        assertContentEquals(intArrayOf(1, 2, 1, 3), d2.expandNDims(0, 2).shape)
+    }
+
+    @Test
+    fun testExpandDimsIsAView() {
+        val a = mk.d2array(2, 3) { it }
+        val slice = a[0 until 2, 1 until 3] as NDArray<Int, D2>
+        val expanded = slice.expandDims(1)
+
+        assertSame(a.data, expanded.data)
+        assertEquals(slice.toList(), expanded.toList())
+    }
+
+    // Dimension bookkeeping
+
+    @Test
+    fun testReshapeReportsTheRequestedDimension() {
+        // `unsqueeze` yields DN(2); reshaping back to a 2D shape must report D2, or the result
+        // compares unequal to an identically shaped D2 array.
+        val a = mk.ndarrayOf(1, 2, 3, 4, 5, 6).unsqueeze(0)
+        assertEquals(mk.ndarray(mk[mk[1, 2, 3, 4, 5, 6]]), a.reshape(1, 6))
+        assertEquals(mk.ndarray(mk[mk[1, 2, 3], mk[4, 5, 6]]), a.reshape(2, 3))
+    }
+
+    // Edge cases
+
+    @Test
+    fun testShapeChangesOfAnEmptyArray() {
+        val a = mk.zeros<Double>(0, 3)
+
+        val unsqueezed = a.unsqueeze(0)
+        assertContentEquals(intArrayOf(1, 0, 3), unsqueezed.shape)
+        assertEquals(0, unsqueezed.size)
+
+        val squeezed = mk.zeros<Double>(0, 1, 3).squeeze()
+        assertContentEquals(intArrayOf(0, 3), squeezed.shape)
+    }
+
+    // reshapeStrides
+
+    @Test
+    fun testReshapeStridesOfContiguousLayout() {
+        assertContentEquals(intArrayOf(2, 1), reshapeStrides(intArrayOf(2, 3), intArrayOf(3, 1), intArrayOf(3, 2)))
+        assertContentEquals(intArrayOf(1), reshapeStrides(intArrayOf(2, 3), intArrayOf(3, 1), intArrayOf(6)))
+        assertContentEquals(
+            intArrayOf(6, 3, 1),
+            reshapeStrides(intArrayOf(2, 3), intArrayOf(3, 1), intArrayOf(1, 2, 3))
+        )
+    }
+
+    @Test
+    fun testReshapeStridesIgnoresSizeOneAxes() {
+        // A size-one axis in the middle must not break up an otherwise contiguous group.
+        assertContentEquals(
+            intArrayOf(12, 1),
+            reshapeStrides(intArrayOf(2, 1, 4), intArrayOf(12, 4, 1), intArrayOf(2, 4))
+        )
+    }
+
+    @Test
+    fun testReshapeStridesRejectsLayoutsThatNeedACopy() {
+        // Transposed (3, 2): rows are 1 apart, columns 3 apart — the axes cannot be merged.
+        assertNull(reshapeStrides(intArrayOf(3, 2), intArrayOf(1, 3), intArrayOf(6)))
+        // A slice whose rows are further apart than their own width.
+        assertNull(reshapeStrides(intArrayOf(3, 2), intArrayOf(4, 1), intArrayOf(6)))
+    }
+
+    @Test
+    fun testReshapeStridesKeepsConsistentLayoutsPacked() {
+        // A view of a contiguous array must stay recognisably contiguous after reshaping.
+        for (newShape in listOf(intArrayOf(24), intArrayOf(4, 6), intArrayOf(2, 3, 4), intArrayOf(1, 24, 1))) {
+            assertContentEquals(
+                computeStrides(newShape),
+                reshapeStrides(intArrayOf(2, 12), intArrayOf(12, 1), newShape),
+                newShape.joinToString(prefix = "shape(", postfix = ")")
+            )
+        }
+    }
+}

--- a/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/SliceTest.kt
+++ b/multik-core/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/ndarray/data/SliceTest.kt
@@ -62,6 +62,7 @@ class SliceTest {
 
     @Test
     fun testBase() {
+        // `base` always points at the array that owns the buffer, not at the immediate parent view.
         val a = mk.ndarrayOf(0, 1, 2, 3, 4, 5)
         val b = a[1 until 5]
         val c = a[1 until 3]
@@ -72,15 +73,16 @@ class SliceTest {
         val a2 = a.reshape(3, 2)
         val b2 = b.reshape(4, 1)
         assertSame(a, a2.base)
-        assertSame(null, b2.base)
+        // (4, 1) is expressible with strides over the slice, so no copy is made.
+        assertSame(a, b2.base)
 
         val d1 = b2.squeeze()
         val d2 = d1.unsqueeze()
-        assertSame(b2, d1.base)
-        assertSame(b2, d2.base)
+        assertSame(a, d1.base)
+        assertSame(a, d2.base)
 
         val e = b2.transpose()
-        assertSame(b2, e.base)
+        assertSame(a, e.base)
 
         val f = a2[1]
         assertSame(a, f.base)

--- a/multik-core/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/api/io/io.kt
+++ b/multik-core/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/api/io/io.kt
@@ -59,22 +59,25 @@ public inline fun <reified T : Any, reified D : Dimension> Multik.read(path: Pat
  * @param dtype the expected element data type.
  * @param dim the expected dimension.
  * @throws NoSuchFileException if the file does not exist.
- * @throws Exception if the format is unsupported or incompatible with [dtype]/[dim].
+ * @throws IllegalArgumentException if the format is unsupported or incompatible with [dtype]/[dim].
  */
 public fun <T : Any, D : Dimension> Multik.read(path: Path, dtype: DataType, dim: D): NDArray<T, D> {
     if (path.notExists()) throw NoSuchFileException(path.toFile())
     return when (path.extension) {
         FileFormats.NPY.extension -> {
-            if (dtype.isComplex()) throw Exception("NPY format only supports Number types")
+            require(dtype.isNumber()) { "NPY format does not support ${dtype.name}: only real numeric types are supported." }
             this.readNPY(path, dtype, dim)
         }
 
         FileFormats.CSV.extension -> {
-            if (dim.d > 2) throw Exception("CSV format only supports 1 and 2 dimensions")
+            require(dim.d <= 2) { "CSV format supports 1- and 2-dimensional arrays, but got dimension ${dim.d}." }
             this.readRaw(path.toFile(), dtype, dim as Dim2) as NDArray<T, D>
         }
 
-        else -> throw Exception("Format ${path.extension} does not support reading ndarrays. If it is `npz` format, try `mk.readNPZ`")
+        else -> throw IllegalArgumentException(
+            "Cannot read an ndarray from a `.${path.extension}` file. Supported formats: `npy`, `csv`. " +
+                "For `npz` archives use `mk.readNPZ`."
+        )
     }
 }
 
@@ -108,21 +111,25 @@ public fun Multik.write(file: File, ndarray: NDArray<*, *>): Unit =
  *
  * @param path path to the output file.
  * @param ndarray the array to write.
- * @throws Exception if the format is unsupported or incompatible with the array's type or dimension.
+ * @throws IllegalArgumentException if the format is unsupported or incompatible with the array's type or dimension.
  */
 public fun Multik.write(path: Path, ndarray: NDArray<*, *>): Unit =
     when (path.extension) {
         FileFormats.NPY.extension -> {
-            require(ndarray.dtype != DataType.ComplexFloatDataType || ndarray.dtype != DataType.ComplexFloatDataType) {
-                "NPY format does not support complex numbers."
+            require(ndarray.dtype.isNumber()) {
+                "NPY format does not support ${ndarray.dtype.name}: only real numeric types are supported."
             }
             this.writeNPY(path, ndarray as NDArray<out Number, *>)
         }
 
         FileFormats.CSV.extension -> {
-            require(ndarray.dim.d < 2) { "Expected array of dimension less than 2, but got array of dimension ${ndarray.dim.d}." }
+            require(ndarray.dim.d <= 2) {
+                "CSV format supports 1- and 2-dimensional arrays, but got dimension ${ndarray.dim.d}."
+            }
             this.writeCSV(path.toFile(), ndarray as NDArray<*, out Dim2>)
         }
 
-        else -> throw Exception("Unknown format `${path.extension}`. Please use one of the supported formats: `npy`, `csv`.")
+        else -> throw IllegalArgumentException(
+            "Cannot write an ndarray to a `.${path.extension}` file. Supported formats: `npy`, `csv`."
+        )
     }

--- a/multik-core/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/api/io/npy.kt
+++ b/multik-core/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/api/io/npy.kt
@@ -50,11 +50,10 @@ public inline fun <reified T : Number, reified D : Dimension> Multik.readNPY(pat
  * @param path path to the `.npy` file.
  * @param dtype the expected element data type.
  * @param dim the expected dimension.
- * @throws Exception if [dtype] is a complex type.
- * @throws IllegalArgumentException if the file's shape does not match [dim].
+ * @throws IllegalArgumentException if [dtype] is a complex type, or if the file's shape does not match [dim].
  */
 public fun <T : Any, D : Dimension> Multik.readNPY(path: Path, dtype: DataType, dim: D): NDArray<T, D> {
-    if (dtype.isComplex()) throw Exception("NPY format only supports Number types")
+    require(dtype.isNumber()) { "NPY format does not support ${dtype.name}: only real numeric types are supported." }
     val npyArray: NpyArray = NpyFile.read(path)
     require(npyArray.shape.size == dim.d) { "Not match dimensions: shape of npy array = ${npyArray.shape.joinToString()}, and dimension = ${dim.d}" }
 
@@ -65,7 +64,7 @@ public fun <T : Any, D : Dimension> Multik.readNPY(path: Path, dtype: DataType, 
         DataType.LongDataType -> MemoryViewLongArray(npyArray.asLongArray())
         DataType.ShortDataType -> MemoryViewShortArray(npyArray.asShortArray())
         DataType.ByteDataType -> MemoryViewByteArray(npyArray.asByteArray())
-        else -> throw Exception("not supported complex arrays")
+        else -> throw IllegalArgumentException("NPY format does not support ${dtype.name}: only real numeric types are supported.")
     } as MemoryView<T>
 
     return NDArray(data, shape = npyArray.shape, dim = dim)

--- a/multik-core/src/jvmTest/kotlin/org/jetbrains/kotlinx/multik/io/IOErrorsTest.kt
+++ b/multik-core/src/jvmTest/kotlin/org/jetbrains/kotlinx/multik/io/IOErrorsTest.kt
@@ -1,0 +1,88 @@
+package org.jetbrains.kotlinx.multik.io
+
+import org.jetbrains.kotlinx.multik.api.io.read
+import org.jetbrains.kotlinx.multik.api.io.write
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.ndarray
+import org.jetbrains.kotlinx.multik.api.zeros
+import org.jetbrains.kotlinx.multik.ndarray.complex.complexDoubleArrayOf
+import org.jetbrains.kotlinx.multik.ndarray.complex.complexFloatArrayOf
+import org.jetbrains.kotlinx.multik.ndarray.complex.i
+import org.jetbrains.kotlinx.multik.ndarray.complex.plus
+import org.jetbrains.kotlinx.multik.ndarray.data.D1
+import org.jetbrains.kotlinx.multik.ndarray.data.D2
+import org.jetbrains.kotlinx.multik.ndarray.data.DataType
+import kotlin.io.path.Path
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class IOErrorsTest {
+
+    @Test
+    fun testWritingComplexArraysToNpyIsRejected() {
+        val path = Path("src/jvmTest/resources/data/npy/testComplexReject.npy")
+
+        // Both complex types must be rejected: the guard used to name ComplexFloat twice, so
+        // ComplexDouble slipped through into `writeNPY`.
+        val complexFloat = mk.ndarray(complexFloatArrayOf(1f + 2f.i, 3f + 4f.i))
+        val complexDouble = mk.ndarray(complexDoubleArrayOf(1.0 + 2.0.i, 3.0 + 4.0.i))
+
+        assertContains(
+            assertFailsWith<IllegalArgumentException> { mk.write(path, complexFloat) }.message.orEmpty(),
+            "ComplexFloatDataType"
+        )
+        assertContains(
+            assertFailsWith<IllegalArgumentException> { mk.write(path, complexDouble) }.message.orEmpty(),
+            "ComplexDoubleDataType"
+        )
+        path.deleteIfExists()
+    }
+
+    @Test
+    fun testReadingNpyWithAComplexDataTypeIsRejected() {
+        val e = assertFailsWith<IllegalArgumentException> {
+            mk.read<Any, D1>(Path(testNpy("a1d")), DataType.ComplexDoubleDataType, D1)
+        }
+        assertContains(e.message.orEmpty(), "ComplexDoubleDataType")
+    }
+
+    @Test
+    fun testWritingA2dArrayToCsvIsAllowed() {
+        // `read` accepts D1 and D2 and `writeCSV` handles both, but `write` used to reject D2.
+        val a = mk.ndarray(mk[mk[1.0, 2.0], mk[3.0, 4.0]])
+        val path = Path("src/jvmTest/resources/data/csv/testWrite2dArray.csv")
+
+        mk.write(path, a)
+        assertTrue(path.exists())
+        assertEquals(a, mk.read<Double, D2>(path))
+        path.deleteIfExists()
+    }
+
+    @Test
+    fun testWritingA3dArrayToCsvIsRejected() {
+        val path = Path("src/jvmTest/resources/data/csv/testWrite3dArray.csv")
+        val e = assertFailsWith<IllegalArgumentException> { mk.write(path, mk.zeros<Double>(2, 2, 2)) }
+        assertContains(e.message.orEmpty(), "dimension 3")
+        path.deleteIfExists()
+    }
+
+    @Test
+    fun testUnknownFormatIsRejected() {
+        val path = Path("src/jvmTest/resources/data/csv/testUnknownFormat.parquet")
+
+        val write = assertFailsWith<IllegalArgumentException> { mk.write(path, mk.zeros<Double>(2)) }
+        assertContains(write.message.orEmpty(), "parquet")
+
+        path.writeText("1.0\n2.0\n")
+        val read = assertFailsWith<IllegalArgumentException> { mk.read<Double, D1>(path) }
+        assertContains(read.message.orEmpty(), "parquet")
+        assertContains(read.message.orEmpty(), "npy")
+        path.deleteIfExists()
+    }
+}

--- a/multik-default/src/desktopMain/kotlin/org.jetbrains.kotlinx.multik.default/DefaultEngineFactory.kt
+++ b/multik-default/src/desktopMain/kotlin/org.jetbrains.kotlinx.multik.default/DefaultEngineFactory.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlinx.multik.openblas.NativeEngine
 internal actual object DefaultEngineFactory : EngineFactory {
     actual override fun getEngine(type: EngineType?): Engine =
         when (type) {
-            null -> error("Pass NativeEngineType of KEEngineType")
+            null -> throw IllegalArgumentException("Engine type is required: pass NativeEngineType or KEEngineType.")
             KEEngineType -> KEEngine()
             NativeEngineType -> NativeEngine()
             DefaultEngineType -> error("Default Engine doesn't link to Default Engine")

--- a/multik-default/src/iosMain/kotlin/org.jetbrains.kotlinx.multik.default/DefaultEngineFactory.kt
+++ b/multik-default/src/iosMain/kotlin/org.jetbrains.kotlinx.multik.default/DefaultEngineFactory.kt
@@ -12,6 +12,8 @@ internal actual object DefaultEngineFactory : EngineFactory {
     actual override fun getEngine(type: EngineType?): Engine =
         when (type) {
             null, KEEngineType, DefaultEngineType -> KEEngine()
-            NativeEngineType -> error("Don't exist native engine for iOS targets")
+            NativeEngineType -> throw UnsupportedOperationException(
+                "There is no native engine for iOS targets; use KEEngineType."
+            )
         }
 }

--- a/multik-default/src/jsMain/kotlin/org.jetbrains.kotlinx.multik.default/DefaultEngineFactory.kt
+++ b/multik-default/src/jsMain/kotlin/org.jetbrains.kotlinx.multik.default/DefaultEngineFactory.kt
@@ -12,6 +12,8 @@ internal actual object DefaultEngineFactory : EngineFactory {
     actual override fun getEngine(type: EngineType?): Engine =
         when (type) {
             null, KEEngineType, DefaultEngineType -> KEEngine()
-            NativeEngineType -> error("Don't exist native engine for iOS targets")
+            NativeEngineType -> throw UnsupportedOperationException(
+                "There is no native engine for JS targets; use KEEngineType."
+            )
         }
 }

--- a/multik-default/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/default/DefaultEngineFactory.kt
+++ b/multik-default/src/jvmMain/kotlin/org/jetbrains/kotlinx/multik/default/DefaultEngineFactory.kt
@@ -12,7 +12,7 @@ import org.jetbrains.kotlinx.multik.openblas.JvmNativeEngine
 internal actual object DefaultEngineFactory : EngineFactory {
     actual override fun getEngine(type: EngineType?): Engine =
         when (type) {
-            null -> error("Pass NativeEngineType of KEEngineType")
+            null -> throw IllegalArgumentException("Engine type is required: pass NativeEngineType or KEEngineType.")
             KEEngineType -> KEEngine()
             NativeEngineType -> {
                 if (supportNative)

--- a/multik-default/src/wasmJsMain/kotlin/org/jetbrains/kotlinx/multik/default/DefaultEngineFactory.kt
+++ b/multik-default/src/wasmJsMain/kotlin/org/jetbrains/kotlinx/multik/default/DefaultEngineFactory.kt
@@ -12,6 +12,8 @@ internal actual object DefaultEngineFactory : EngineFactory {
     actual override fun getEngine(type: EngineType?): Engine =
         when (type) {
             null, KEEngineType, DefaultEngineType -> KEEngine()
-            NativeEngineType -> error("Don't exist native engine for iOS targets")
+            NativeEngineType -> throw UnsupportedOperationException(
+                "There is no native engine for WASM targets; use KEEngineType."
+            )
         }
 }

--- a/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/LinAlgEx.kt
+++ b/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/LinAlgEx.kt
@@ -53,7 +53,7 @@ internal object KELinAlgEx : LinAlgEx {
             DataType.FloatDataType -> solveFloat(_a as D2Array<Float>, _b as D2Array<Float>)
             DataType.ComplexDoubleDataType -> solveComplexDouble(_a as D2Array<ComplexDouble>, _b as D2Array<ComplexDouble>)
             DataType.ComplexFloatDataType -> solveComplexFloat(_a as D2Array<ComplexFloat>, _b as D2Array<ComplexFloat>)
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`solve` is not supported for ${dtype.name}.")
         }
         return (if (b.dim.d == 2) ans else ans.reshape(ans.shape[0])) as NDArray<O, D>
     }

--- a/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/dot.kt
+++ b/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/dot.kt
@@ -71,7 +71,7 @@ private fun <T> dotMatrixCommon(a: MultiArray<T, D2>, b: MultiArray<T, D2>): D2A
                 a.data.getByteArray(), a.offset, a.strides, b.data.getByteArray(), b.offset, b.strides,
                 newShape[0], newShape[1], a.shape[1], ret.data.getByteArray(), ret.strides[0]
             )
-        else -> throw UnsupportedOperationException()
+        else -> throw UnsupportedOperationException("`dot` of two matrices is not supported for ${a.dtype.name}.")
     }
     return ret
 }
@@ -306,7 +306,7 @@ private fun <T> dotMatrixToVectorCommon(a: MultiArray<T, D2>, b: MultiArray<T, D
                 a.data.getByteArray(), a.offset, a.strides, b.data.getByteArray(), b.offset, b.strides[0],
                 newShape[0], b.shape[0], ret.data.getByteArray()
             )
-        else -> throw UnsupportedOperationException()
+        else -> throw UnsupportedOperationException("`dot` of a matrix and a vector is not supported for ${a.dtype.name}.")
     }
     return ret
 }
@@ -459,7 +459,7 @@ internal fun <T : Number> dotVecToVec(a: MultiArray<T, D1>, b: MultiArray<T, D1>
             a.data.getByteArray(), a.offset, a.strides[0],
             b.data.getByteArray(), b.offset, b.strides[0], a.size
         )
-    else -> throw UnsupportedOperationException()
+    else -> throw UnsupportedOperationException("`dot` of two vectors is not supported for ${a.dtype.name}.")
 } as T
 
 internal fun <T : Complex> dotVecToVecComplex(a: MultiArray<T, D1>, b: MultiArray<T, D1>): T = when (a.dtype) {
@@ -473,7 +473,7 @@ internal fun <T : Complex> dotVecToVecComplex(a: MultiArray<T, D1>, b: MultiArra
             a.data.getComplexDoubleArray(), a.offset, a.strides[0],
             b.data.getComplexDoubleArray(), b.offset, b.strides[0], a.size
         )
-    else -> throw UnsupportedOperationException()
+    else -> throw UnsupportedOperationException("`dot` of two complex vectors is not supported for ${a.dtype.name}.")
 } as T
 
 private fun dotVecToVec(

--- a/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/eigen.kt
+++ b/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/eigen.kt
@@ -32,7 +32,7 @@ internal fun <T, O : Any> eigenValuesCommon(a: MultiArray<T, D2>, dtype: DataTyp
     return when (dtype) {
         DataType.ComplexFloatDataType -> eigenvaluesFloat(mat as MultiArray<ComplexFloat, D2>)
         DataType.ComplexDoubleDataType -> eigenvaluesDouble(mat as MultiArray<ComplexDouble, D2>)
-        else -> throw UnsupportedOperationException()
+        else -> throw UnsupportedOperationException("`eig` is not supported for ${dtype.name}.")
     } as D1Array<O>
 }
 

--- a/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/pluDecomposition.kt
+++ b/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/linalg/pluDecomposition.kt
@@ -42,7 +42,7 @@ internal fun <T> pluCompressed(mat: MultiArray<T, D2>): Triple<D1Array<Int>, D2A
             pluDecompositionInplaceComplexFloat(mat as D2Array<ComplexFloat>, perm)
             fillLowerMatrix(L as D2Array<ComplexFloat>, mat, ComplexFloat.one)
         }
-        else -> throw UnsupportedOperationException()
+        else -> throw UnsupportedOperationException("PLU decomposition is not supported for ${mat.dtype.name}.")
     }
 
     // todo fillUpperMatrix

--- a/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/math/KEMathEx.kt
+++ b/multik-kotlin/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/kotlin/math/KEMathEx.kt
@@ -78,10 +78,8 @@ internal object KEMathEx : MathEx {
     ): NDArray<Double, D> {
         val iter = a.iterator()
         val data = initMemoryView(a.size, DataType.DoubleDataType) {
-            if (iter.hasNext())
-                function(iter.next().toDouble())
-            else
-                0.0
+            check(iter.hasNext()) { "Iterator over an array of ${a.size} elements was exhausted early." }
+            function(iter.next().toDouble())
         }
         return NDArray(data, 0, a.shape, dim = a.dim)
     }
@@ -92,10 +90,8 @@ internal object KEMathEx : MathEx {
     ): NDArray<Float, D> {
         val iter = a.iterator()
         val data = initMemoryView(a.size, DataType.FloatDataType) {
-            if (iter.hasNext())
-                function(iter.next())
-            else
-                0f
+            check(iter.hasNext()) { "Iterator over an array of ${a.size} elements was exhausted early." }
+            function(iter.next())
         }
         return NDArray(data, 0, a.shape, dim = a.dim)
     }
@@ -106,7 +102,7 @@ internal object KEMathEx : MathEx {
     ): NDArray<T, D> {
         val iter = a.iterator()
         val data = initMemoryView(a.size, a.dtype) {
-            if (!iter.hasNext()) throw Exception("")
+            check(iter.hasNext()) { "Iterator over an array of ${a.size} elements was exhausted early." }
             function(iter.next())
         }
         return NDArray(data, 0, a.shape, dim = a.dim)

--- a/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/linAlg/KELinAlgErrorTest.kt
+++ b/multik-kotlin/src/commonTest/kotlin/org/jetbrains/kotlinx/multik_kotlin/linAlg/KELinAlgErrorTest.kt
@@ -1,0 +1,37 @@
+package org.jetbrains.kotlinx.multik_kotlin.linAlg
+
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.ndarray
+import org.jetbrains.kotlinx.multik.kotlin.linalg.KELinAlgEx
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * The exception types a failing decomposition throws are part of the engine contract: `multik-default`
+ * chooses the engine at runtime, so `KEEngine` and `NativeEngine` must agree. The mirror of this class
+ * is `NativeLinAlgErrorTest` in multik-openblas.
+ */
+class KELinAlgErrorTest {
+
+    private val singular = mk.ndarray(mk[mk[1.0, 2.0], mk[2.0, 4.0]])
+
+    @Test
+    fun testSolveOfASingularMatrixThrowsArithmeticException() {
+        val b = mk.ndarray(mk[mk[1.0], mk[1.0]])
+        assertFailsWith<ArithmeticException> { KELinAlgEx.solve(singular, b) }
+    }
+
+    @Test
+    fun testInvOfASingularMatrixThrowsArithmeticException() {
+        assertFailsWith<ArithmeticException> { KELinAlgEx.inv(singular) }
+    }
+
+    @Test
+    fun testMismatchedShapesThrowIllegalArgumentException() {
+        val b = mk.ndarray(mk[1.0, 2.0, 3.0])
+        assertFailsWith<IllegalArgumentException> { KELinAlgEx.solve(singular, b) }
+        assertFailsWith<IllegalArgumentException> {
+            KELinAlgEx.solve(mk.ndarray(mk[mk[1.0, 2.0, 3.0], mk[4.0, 5.0, 6.0]]), b)
+        }
+    }
+}

--- a/multik-openblas/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/openblas/linalg/NativeLinAlgEx.kt
+++ b/multik-openblas/src/commonMain/kotlin/org/jetbrains/kotlinx/multik/openblas/linalg/NativeLinAlgEx.kt
@@ -45,12 +45,14 @@ internal object NativeLinAlgEx : LinAlgEx {
             DataType.DoubleDataType -> JniLinAlg.inv(mat.shape[0], mat.data.getDoubleArray(), mat.strides[0])
             DataType.ComplexFloatDataType -> JniLinAlg.invC(mat.shape[0], mat.data.getFloatArray(), mat.strides[0])
             DataType.ComplexDoubleDataType -> JniLinAlg.invC(mat.shape[0], mat.data.getDoubleArray(), mat.strides[0])
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`inv` is not supported for ${mat.dtype.name}.")
         }
 
         when {
-            info < 0 -> throw IllegalArgumentException("${-info} argument had illegal value. ")
-            info > 0 -> throw Exception("U($info, $info) is exactly zero. Matrix is singular and its inverse could not be computed")
+            info < 0 -> error("LAPACK getri/getrf rejected argument ${-info} passed by Multik.")
+            info > 0 -> throw ArithmeticException(
+                "Matrix is singular: U($info, $info) is exactly zero, so the inverse could not be computed."
+            )
         }
 
         return mat as NDArray<T, D2>
@@ -86,10 +88,14 @@ internal object NativeLinAlgEx : LinAlgEx {
             DataType.ComplexDoubleDataType -> JniLinAlg.solveC(
                 a.shape[0], nhrs, a.data.getDoubleArray(), a.strides[0], b.data.getDoubleArray(), b.strides[0]
             )
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`solve` is not supported for ${a.dtype.name}.")
         }
+        if (info < 0) error("LAPACK gesv rejected argument ${-info} passed by Multik.")
         if (info > 0) {
-            throw Exception("The diagonal element of the triangular factor of a is zero, so that A is singular. The solution could not be computed.")
+            throw ArithmeticException(
+                "Matrix a is singular or almost singular: U($info, $info) of its triangular factor is zero, " +
+                    "so the solution could not be computed."
+            )
         }
 
         return b as NDArray<T, D>
@@ -127,10 +133,10 @@ internal object NativeLinAlgEx : LinAlgEx {
             DataType.DoubleDataType -> JniLinAlg.qr(m, n, q.data.getDoubleArray(), q.strides[0], r.data.getDoubleArray())
             DataType.ComplexFloatDataType -> JniLinAlg.qrC(m, n, q.data.getFloatArray(), q.strides[0], r.data.getFloatArray())
             DataType.ComplexDoubleDataType -> JniLinAlg.qrC(m, n, q.data.getDoubleArray(), q.strides[0], r.data.getDoubleArray())
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`qr` is not supported for ${retDType.name}.")
         }
 
-        if (info < 0) throw IllegalArgumentException("${-info} argument had illegal value. ")
+        if (info < 0) error("LAPACK geqrf/orgqr rejected argument ${-info} passed by Multik.")
 
         // TODO internal copyOf(end: Int)
         return Pair(q[Slice.bounds, 0 until mn].deepCopy() as D2Array<O>, r)
@@ -146,7 +152,7 @@ internal object NativeLinAlgEx : LinAlgEx {
         when (mat.dtype) {
             DataType.ComplexFloatDataType -> pluCommon(mat, mat.dtype, ComplexFloat.one as T)
             DataType.ComplexDoubleDataType -> pluCommon(mat, mat.dtype, ComplexDouble.one as T)
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`plu` is not supported for ${mat.dtype.name}.")
         }
 
     private fun <T, O : Any> pluCommon(mat: MultiArray<T, D2>, dtype: DataType, one: O): Triple<D2Array<O>, D2Array<O>, D2Array<O>> {
@@ -161,10 +167,10 @@ internal object NativeLinAlgEx : LinAlgEx {
             DataType.DoubleDataType -> JniLinAlg.plu(m, n, a.data.getDoubleArray(), a.strides[0], ipiv)
             DataType.ComplexFloatDataType -> JniLinAlg.pluC(m, n, a.data.getFloatArray(), a.strides[0], ipiv)
             DataType.ComplexDoubleDataType -> JniLinAlg.pluC(m, n, a.data.getDoubleArray(), a.strides[0], ipiv)
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`plu` is not supported for ${dtype.name}.")
         }
 
-        if (info < 0) throw IllegalArgumentException("${-info} argument had illegal value. ")
+        if (info < 0) error("LAPACK getrf rejected argument ${-info} passed by Multik.")
 
         val P = mk.identity<O>(m, dtype)
         val L = mk.zeros<O, D2>(intArrayOf(m, mn), dtype)
@@ -209,7 +215,7 @@ internal object NativeLinAlgEx : LinAlgEx {
         when (mat.dtype) {
             DataType.ComplexFloatDataType -> svdCommon(mat, mat.dtype)
             DataType.ComplexDoubleDataType -> svdCommon(mat, mat.dtype)
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`svd` is not supported for ${mat.dtype.name}.")
         }
 
     private fun <T, O: Any> svdCommon(mat: MultiArray<T, D2>, dtype: DataType): Triple<D2Array<O>, D1Array<O>, D2Array<O>> {
@@ -246,13 +252,13 @@ internal object NativeLinAlgEx : LinAlgEx {
                     u.data.getDoubleArray(), ldu, vt.data.getDoubleArray(), ldvt
                 )
 
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`svd` is not supported for ${dtype.name}.")
         }
 
         when {
-            info == -4 -> throw IllegalStateException("mat had a NaN entry.")
-            info < 0 -> throw IllegalArgumentException("the ${-info}-th argument had and illegal value.")
-            info > 0 -> throw IllegalStateException("DBDSDC did not converge, updating process failed.")
+            info == -4 -> throw IllegalArgumentException("mat has a NaN entry.")
+            info < 0 -> error("LAPACK gesdd rejected argument ${-info} passed by Multik.")
+            info > 0 -> throw ArithmeticException("Singular value decomposition did not converge.")
         }
 
         return Triple(u, s, vt)
@@ -297,12 +303,14 @@ internal object NativeLinAlgEx : LinAlgEx {
                 vr = if (computeVectors) mk.zeros(intArrayOf(n, n), DataType.ComplexDoubleDataType) else null
                 JniLinAlg.eig(n, mat.data.getDoubleArray(), w.data.getDoubleArray(), computeV, vr?.data?.getDoubleArray())
             }
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`eig` is not supported for ${mat.dtype.name}.")
         }
 
         when {
-            info < 0 -> throw IllegalArgumentException("The ${-info}-th argument had an illegal value")
-            info > 0 -> throw Exception("Failed to compute all the eigenvalues.")
+            info < 0 -> error("LAPACK geev rejected argument ${-info} passed by Multik.")
+            info > 0 -> throw ArithmeticException(
+                "Eigenvalue computation did not converge: only eigenvalues ${info + 1}..$n were computed."
+            )
         }
 
         return Pair(w, vr)
@@ -355,7 +363,7 @@ internal object NativeLinAlgEx : LinAlgEx {
                     transA, aN.offset, aN.data.getDoubleArray(), m, k, lda,
                     transB, bN.offset, bN.data.getDoubleArray(), n, ldb, cView.getDoubleArray()
                 )
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`dot` of two matrices is not supported for ${a.dtype.name}.")
         }
 
         return D2Array(cView, 0, shape, dim = D2)
@@ -402,7 +410,7 @@ internal object NativeLinAlgEx : LinAlgEx {
                     transA, aN.offset, aN.data.getDoubleArray(), m, n, lda,
                     b.offset, b.data.getDoubleArray(), b.strides[0], cView.getDoubleArray()
                 )
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`dot` of a matrix and a vector is not supported for ${a.dtype.name}.")
         }
 
         return D1Array(cView, 0, shape, dim = D1)
@@ -416,7 +424,7 @@ internal object NativeLinAlgEx : LinAlgEx {
                 JniLinAlg.dotVV(a.size, a.offset, a.data.getFloatArray(), a.strides[0], b.offset, b.data.getFloatArray(), b.strides[0])
             DataType.DoubleDataType ->
                 JniLinAlg.dotVV(a.size, a.offset, a.data.getDoubleArray(), a.strides[0], b.offset, b.data.getDoubleArray(), b.strides[0])
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`dot` of two vectors is not supported for ${a.dtype.name}.")
         } as T
     }
 
@@ -428,7 +436,7 @@ internal object NativeLinAlgEx : LinAlgEx {
                 JniLinAlg.dotVVC(a.size, a.offset, a.data.getFloatArray(), a.strides[0], b.offset, b.data.getFloatArray(), b.strides[0])
             DataType.ComplexDoubleDataType ->
                 JniLinAlg.dotVVC(a.size, a.offset, a.data.getDoubleArray(), a.strides[0], b.offset, b.data.getDoubleArray(), b.strides[0])
-            else -> throw UnsupportedOperationException()
+            else -> throw UnsupportedOperationException("`dot` of two complex vectors is not supported for ${a.dtype.name}.")
         } as T
     }
 }

--- a/multik-openblas/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/openblas/linalg/NativeLinAlgErrorTest.kt
+++ b/multik-openblas/src/commonTest/kotlin/org/jetbrains/kotlinx/multik/openblas/linalg/NativeLinAlgErrorTest.kt
@@ -1,0 +1,37 @@
+package org.jetbrains.kotlinx.multik.openblas.linalg
+
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.api.ndarray
+import org.jetbrains.kotlinx.multik.openblas.NativeTestBase
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * The exception types a failing decomposition throws are part of the engine contract: `multik-default`
+ * chooses the engine at runtime, so `NativeEngine` and `KEEngine` must agree. The mirror of this class
+ * is `KELinAlgErrorTest` in multik-kotlin.
+ */
+class NativeLinAlgErrorTest : NativeTestBase() {
+
+    private val singular = mk.ndarray(mk[mk[1.0, 2.0], mk[2.0, 4.0]])
+
+    @Test
+    fun testSolveOfASingularMatrixThrowsArithmeticException() {
+        val b = mk.ndarray(mk[mk[1.0], mk[1.0]])
+        assertFailsWith<ArithmeticException> { NativeLinAlgEx.solve(singular, b) }
+    }
+
+    @Test
+    fun testInvOfASingularMatrixThrowsArithmeticException() {
+        assertFailsWith<ArithmeticException> { NativeLinAlgEx.inv(singular) }
+    }
+
+    @Test
+    fun testMismatchedShapesThrowIllegalArgumentException() {
+        val b = mk.ndarray(mk[1.0, 2.0, 3.0])
+        assertFailsWith<IllegalArgumentException> { NativeLinAlgEx.solve(singular, b) }
+        assertFailsWith<IllegalArgumentException> {
+            NativeLinAlgEx.solve(mk.ndarray(mk[mk[1.0, 2.0, 3.0], mk[4.0, 5.0, 6.0]]), b)
+        }
+    }
+}

--- a/multik-openblas/src/nativeMain/kotlin/org/jetbrains/kotlinx/multik/openblas/math/JniMath.kt
+++ b/multik-openblas/src/nativeMain/kotlin/org/jetbrains/kotlinx/multik/openblas/math/JniMath.kt
@@ -118,7 +118,7 @@ internal actual object JniMath {
                 )
             }
 
-            else -> throw Exception("Only primitive arrays are supported for Kotlin/Native `argMin`")
+            else -> throw UnsupportedOperationException("Only primitive arrays are supported for Kotlin/Native `argMin`")
         }
 
     actual fun argMax(arr: Any, offset: Int, size: Int, shape: IntArray, strides: IntArray?, dtype: Int): Int =
@@ -195,7 +195,7 @@ internal actual object JniMath {
                 )
             }
 
-            else -> throw Exception("Only primitive arrays are supported for Kotlin/Native `argMax`")
+            else -> throw UnsupportedOperationException("Only primitive arrays are supported for Kotlin/Native `argMax`")
         }
 
     actual fun exp(arr: FloatArray, size: Int): Boolean = arr.usePinned {

--- a/multik-openblas/src/nativeMain/kotlin/org/jetbrains/kotlinx/multik/openblas/stat/JniStat.kt
+++ b/multik-openblas/src/nativeMain/kotlin/org/jetbrains/kotlinx/multik/openblas/stat/JniStat.kt
@@ -14,6 +14,6 @@ internal actual object JniStat {
         is LongArray -> arr.usePinned { array_median(it.addressOf(0), size, dtype) }
         is ByteArray -> arr.usePinned { array_median(it.addressOf(0), size, dtype) }
         is ShortArray -> arr.usePinned { array_median(it.addressOf(0), size, dtype) }
-        else -> throw Exception("Only primitive arrays are supported for Kotlin/Native `median`")
+        else -> throw UnsupportedOperationException("Only primitive arrays are supported for Kotlin/Native `median`")
     }
 }


### PR DESCRIPTION
Closes #135, closes #252, closes #257.

## Shape ops return views (#135, #252)

`reshape`, `squeeze`, `unsqueeze` and `expandDims` copied whenever the array was not `consistent`.
They now compute strides for the new shape over the existing buffer — NumPy's rule — and copy only
when no such strides exist, e.g. `transpose().reshape(6)`, where axes genuinely have to be merged.
One internal helper, `reshapeStrides`, backs all of them.

Bugs found on the way:

- **`squeeze` returned wrong data.** It passed the new shape without strides, so they were recomputed
  as if the array were packed. On a `(2,3,4)` array, `a[0 until 2, 1 until 2, 0 until 4].squeeze()`
  gave `[4,5,6,7,8,9,10,11]` instead of `[4,5,6,7,16,17,18,19]` — silently, no exception.
- **`expandDims` on D4 and `expandNDims` ignored their axis argument** — both called `unsqueeze()`
  with no axes, so they only changed the static type.
- **`squeeze()` threw on an all-ones shape**, `mk.ndarrayOf(5)` included. Multik has no rank-0 arrays,
  so it now keeps one axis and returns `[1]` — what `squeeze(0)` on the same array already returned.
- **NPY write let complex through:** the guard read `dtype != ComplexFloat || dtype != ComplexFloat`,
  so `ComplexDouble` reached an unchecked cast to `NDArray<out Number, *>`.
- **CSV write rejected D2**, while `writeCSV` has an explicit D2 branch and `read` accepts D1 and D2.

## Error handling (#257)

The engines disagreed: a singular matrix threw `ArithmeticException` in `KEEngine` and a bare
`Exception` in `NativeEngine`. `multik-default` resolves the engine at runtime, so the same user code
behaved differently per platform. Both now throw `ArithmeticException`.

Also: 20 bare `throw Exception` → 0 (four had empty messages); 29 message-less
`UnsupportedOperationException()` → 0, each now naming the operation and dtype; LAPACK `info < 0`
reports an argument *the wrapper* passed, so it is `IllegalStateException` rather than
`IllegalArgumentException` — and `solveCommon` had no `info < 0` check at all, returning garbage on a
negative code; `squeeze`/`unsqueeze` validate axes instead of letting `ArrayIndexOutOfBoundsException`
escape from `MutableList.add`. Policy written down in `CLAUDE.md`.

## Behaviour changes for the release notes

Writes go through to the source where `reshape`/`unsqueeze`/`expandDims` used to return a copy.

| was | now | where |
|---|---|---|
| `Exception` | `ArithmeticException` | native `inv`/`solve`/`eig`: singularity, non-convergence |
| `IllegalStateException` | `ArithmeticException` | native `svd` non-convergence |
| `IllegalStateException` | `IllegalArgumentException` | native `svd` NaN input, `DataType.of`, `toSlice()` |
| `IllegalArgumentException` | `IllegalStateException` | LAPACK `info < 0` |
| `Exception` | `IllegalArgumentException` | npy/csv `read`/`write`, `Number.toPrimitiveType` |
| `IllegalStateException` | shape `[1]` | `squeeze()` on an all-ones shape |
| `IllegalArgumentException` | success | `write` of a D2 array to CSV |
| success | `IllegalArgumentException` | `write` of a `ComplexDouble` array to NPY |

## Testing

2207 tests, 0 failures on **JVM**, **Native** (`macosArm64`) and **iOS simulator**
(`iosSimulatorArm64`) for multik-core, multik-kotlin and multik-openblas. JS and WASM test tasks are
disabled in the build (#247), so those targets are compile-only here.

New tests: `ReshapeTest` (view vs copy, `reshapeStrides` rules, squeeze/unsqueeze axes),
`ErrorHandlingTest`, `IOErrorsTest`, plus mirrored `KELinAlgErrorTest` / `NativeLinAlgErrorTest`
pinning the cross-engine exception contract.

`apiCheck` and `korroCheck` pass — the public API is unchanged, the new helpers are `internal`.

## Checklist

- [x] Existing tests pass
- [x] New/updated tests for changed behavior
- [x] New/updated documentation if necessary
